### PR TITLE
Fix issue tracker link of report button

### DIFF
--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -1747,7 +1747,7 @@ namespace ImageGlass
         {
             try
             {
-                Process.Start("https://code.google.com/p/imageglass/issues/list");
+                Process.Start("https://github.com/d2phap/ImageGlass/issues");
             }
             catch { }
         }


### PR DESCRIPTION
Report button opens the old google code issue tracker. After this patch it will open github issue tracker.