### PR TITLE
Disable compiler optimization for Debug|AnyCPU configuration

### DIFF
--- a/Source/ImageGlass/ImageGlass.csproj
+++ b/Source/ImageGlass/ImageGlass.csproj
@@ -49,7 +49,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
With disabled optimization we can debug and inspect variables via Watch window.
Optimization should be enabled only for Release configuration.