### PR TITLE
Add show hidden image setting (Issue #187)

### DIFF
--- a/Source/Components/ImageGlass.Library/Language/Language.cs
+++ b/Source/Components/ImageGlass.Library/Language/Language.cs
@@ -441,6 +441,7 @@ namespace ImageGlass.Library
             #region Image loading
             Items.Add("frmSetting.lblHeadImageLoading", "Image loading"); //v4.0
             Items.Add("frmSetting.chkFindChildFolder", "Find images in child folder");
+            Items.Add("frmSetting.chkShowHiddenImages", "Show hidden images");
             Items.Add("frmSetting.chkLoopViewer", "Loop back viewer to the first image when reaching the end of the list"); //v4.0
             Items.Add("frmSetting.chkImageBoosterBack", "Turn on Image Booster when navigate back (need more ~20% RAM)"); //v2.0 final
             Items.Add("frmSetting.lblImageLoadingOrder", "Image loading order");

--- a/Source/Components/ImageGlass.Services/Configuration/GlobalSetting.cs
+++ b/Source/Components/ImageGlass.Services/Configuration/GlobalSetting.cs
@@ -42,6 +42,7 @@ namespace ImageGlass.Services.Configuration
         private static bool _isForcedActive = true;
         private static int _currentIndex = -1;
         private static bool _isRecursiveLoading = false;
+        private static bool _isShowingHiddenImages = false;
         private static StringCollection _stringClipboard = new StringCollection();
         private static string _tempDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"ImageGlass\Temp");
         private static Library.Language _langPack = new Library.Language();
@@ -144,6 +145,15 @@ namespace ImageGlass.Services.Configuration
         {
             get { return GlobalSetting._isRecursiveLoading; }
             set { GlobalSetting._isRecursiveLoading = value; }
+        }
+
+        /// <summary>
+        /// Gets, sets showing/loading hidden images
+        /// </summary>
+        public static bool IsShowingHiddenImages
+        {
+            get => _isShowingHiddenImages;
+            set => _isShowingHiddenImages = value;
         }
 
         /// <summary>

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -258,6 +258,16 @@ namespace ImageGlass
                     Application.DoEvents();
 
                     string extension = Path.GetExtension(f).ToLower() ?? ""; //remove blank extension
+                    // checks if image is hidden and ignores it if so
+                    if (GlobalSetting.IsShowingHiddenImages == false)
+                    {
+                        var attributes = File.GetAttributes(f);
+                        var isHidden = attributes.HasFlag(FileAttributes.Hidden);
+                        if (isHidden)
+                        {
+                            return false;
+                        }
+                    }
                     if (extension.Length > 0 && GlobalSetting.AllImageFormats.Contains(extension))
                     {
                         return true;
@@ -1292,6 +1302,9 @@ namespace ImageGlass
             //Recursive loading--------------------------------------------------------------
             GlobalSetting.IsRecursiveLoading = bool.Parse(GlobalSetting.GetConfig("IsRecursiveLoading", "False"));
 
+            //Show hidden images------------------------------------------------------------
+            GlobalSetting.IsShowingHiddenImages = bool.Parse(GlobalSetting.GetConfig("IsShowingHiddenImages", "False"));
+            
             //Load is loop back slideshow---------------------------------------------------
             GlobalSetting.IsLoopBackViewer = bool.Parse(GlobalSetting.GetConfig("IsLoopBackViewer", "True"));
 

--- a/Source/ImageGlass/frmSetting.Designer.cs
+++ b/Source/ImageGlass/frmSetting.Designer.cs
@@ -117,6 +117,7 @@
             this.btnApply = new System.Windows.Forms.Button();
             this.tblayout = new System.Windows.Forms.TableLayoutPanel();
             this.panel4 = new System.Windows.Forms.Panel();
+            this.chkShowHiddenImages = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.picBackgroundColor)).BeginInit();
             this.tabLanguage.SuspendLayout();
             this.tabFileAssociation.SuspendLayout();
@@ -216,7 +217,7 @@
             this.picBackgroundColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.picBackgroundColor.Cursor = System.Windows.Forms.Cursors.Hand;
             this.picBackgroundColor.Location = new System.Drawing.Point(31, 335);
-            this.picBackgroundColor.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.picBackgroundColor.Margin = new System.Windows.Forms.Padding(1);
             this.picBackgroundColor.Name = "picBackgroundColor";
             this.picBackgroundColor.Size = new System.Drawing.Size(67, 27);
             this.picBackgroundColor.TabIndex = 12;
@@ -332,7 +333,7 @@
             "English (default)",
             "Vietnamese"});
             this.cmbLanguage.Location = new System.Drawing.Point(13, 39);
-            this.cmbLanguage.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.cmbLanguage.Margin = new System.Windows.Forms.Padding(1);
             this.cmbLanguage.Name = "cmbLanguage";
             this.cmbLanguage.Size = new System.Drawing.Size(171, 23);
             this.cmbLanguage.TabIndex = 33;
@@ -384,7 +385,7 @@
             this.btnRegisterExt.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnRegisterExt.AutoSize = true;
             this.btnRegisterExt.Location = new System.Drawing.Point(159, 7);
-            this.btnRegisterExt.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.btnRegisterExt.Margin = new System.Windows.Forms.Padding(2);
             this.btnRegisterExt.Name = "btnRegisterExt";
             this.btnRegisterExt.Size = new System.Drawing.Size(159, 25);
             this.btnRegisterExt.TabIndex = 31;
@@ -397,7 +398,7 @@
             this.btnResetExt.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnResetExt.AutoSize = true;
             this.btnResetExt.Location = new System.Drawing.Point(322, 7);
-            this.btnResetExt.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.btnResetExt.Margin = new System.Windows.Forms.Padding(2);
             this.btnResetExt.Name = "btnResetExt";
             this.btnResetExt.Size = new System.Drawing.Size(133, 25);
             this.btnResetExt.TabIndex = 32;
@@ -410,7 +411,7 @@
             this.btnAddNewExt.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnAddNewExt.AutoSize = true;
             this.btnAddNewExt.Location = new System.Drawing.Point(14, 7);
-            this.btnAddNewExt.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.btnAddNewExt.Margin = new System.Windows.Forms.Padding(2);
             this.btnAddNewExt.Name = "btnAddNewExt";
             this.btnAddNewExt.Size = new System.Drawing.Size(50, 25);
             this.btnAddNewExt.TabIndex = 29;
@@ -424,7 +425,7 @@
             this.btnDeleteExt.AutoSize = true;
             this.btnDeleteExt.Enabled = false;
             this.btnDeleteExt.Location = new System.Drawing.Point(68, 7);
-            this.btnDeleteExt.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.btnDeleteExt.Margin = new System.Windows.Forms.Padding(2);
             this.btnDeleteExt.Name = "btnDeleteExt";
             this.btnDeleteExt.Size = new System.Drawing.Size(66, 25);
             this.btnDeleteExt.TabIndex = 30;
@@ -478,7 +479,7 @@
             listViewGroup2});
             this.lvExtension.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
             this.lvExtension.Location = new System.Drawing.Point(15, 60);
-            this.lvExtension.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.lvExtension.Margin = new System.Windows.Forms.Padding(2);
             this.lvExtension.Name = "lvExtension";
             this.lvExtension.Size = new System.Drawing.Size(439, 249);
             this.lvExtension.Sorting = System.Windows.Forms.SortOrder.Ascending;
@@ -532,7 +533,7 @@
             // 
             this.chkShowScrollbar.AutoSize = true;
             this.chkShowScrollbar.Location = new System.Drawing.Point(30, 285);
-            this.chkShowScrollbar.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkShowScrollbar.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowScrollbar.Name = "chkShowScrollbar";
             this.chkShowScrollbar.Size = new System.Drawing.Size(154, 19);
             this.chkShowScrollbar.TabIndex = 12;
@@ -591,7 +592,7 @@
             // 
             this.chkPortableMode.AutoSize = true;
             this.chkPortableMode.Location = new System.Drawing.Point(30, 131);
-            this.chkPortableMode.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkPortableMode.Margin = new System.Windows.Forms.Padding(1);
             this.chkPortableMode.Name = "chkPortableMode";
             this.chkPortableMode.Size = new System.Drawing.Size(142, 19);
             this.chkPortableMode.TabIndex = 7;
@@ -601,7 +602,7 @@
             // panel1
             // 
             this.panel1.Location = new System.Drawing.Point(29, 387);
-            this.panel1.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.panel1.Margin = new System.Windows.Forms.Padding(1);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(73, 21);
             this.panel1.TabIndex = 24;
@@ -610,7 +611,7 @@
             // 
             this.chkConfirmationDelete.AutoSize = true;
             this.chkConfirmationDelete.Location = new System.Drawing.Point(30, 263);
-            this.chkConfirmationDelete.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkConfirmationDelete.Margin = new System.Windows.Forms.Padding(1);
             this.chkConfirmationDelete.Name = "chkConfirmationDelete";
             this.chkConfirmationDelete.Size = new System.Drawing.Size(211, 19);
             this.chkConfirmationDelete.TabIndex = 11;
@@ -621,7 +622,7 @@
             // 
             this.chkAllowMultiInstances.AutoSize = true;
             this.chkAllowMultiInstances.Location = new System.Drawing.Point(30, 219);
-            this.chkAllowMultiInstances.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkAllowMultiInstances.Margin = new System.Windows.Forms.Padding(1);
             this.chkAllowMultiInstances.Name = "chkAllowMultiInstances";
             this.chkAllowMultiInstances.Size = new System.Drawing.Size(238, 19);
             this.chkAllowMultiInstances.TabIndex = 9;
@@ -632,7 +633,7 @@
             // 
             this.chkESCToQuit.AutoSize = true;
             this.chkESCToQuit.Location = new System.Drawing.Point(30, 241);
-            this.chkESCToQuit.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkESCToQuit.Margin = new System.Windows.Forms.Padding(1);
             this.chkESCToQuit.Name = "chkESCToQuit";
             this.chkESCToQuit.Size = new System.Drawing.Size(223, 19);
             this.chkESCToQuit.TabIndex = 10;
@@ -643,7 +644,7 @@
             // 
             this.chkShowToolBar.AutoSize = true;
             this.chkShowToolBar.Location = new System.Drawing.Point(30, 57);
-            this.chkShowToolBar.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkShowToolBar.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowToolBar.Name = "chkShowToolBar";
             this.chkShowToolBar.Size = new System.Drawing.Size(188, 19);
             this.chkShowToolBar.TabIndex = 6;
@@ -664,7 +665,7 @@
             // 
             this.chkWelcomePicture.AutoSize = true;
             this.chkWelcomePicture.Location = new System.Drawing.Point(30, 35);
-            this.chkWelcomePicture.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkWelcomePicture.Margin = new System.Windows.Forms.Padding(1);
             this.chkWelcomePicture.Name = "chkWelcomePicture";
             this.chkWelcomePicture.Size = new System.Drawing.Size(146, 19);
             this.chkWelcomePicture.TabIndex = 5;
@@ -675,7 +676,7 @@
             // 
             this.chkAutoUpdate.AutoSize = true;
             this.chkAutoUpdate.Location = new System.Drawing.Point(30, 197);
-            this.chkAutoUpdate.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkAutoUpdate.Margin = new System.Windows.Forms.Padding(1);
             this.chkAutoUpdate.Name = "chkAutoUpdate";
             this.chkAutoUpdate.Size = new System.Drawing.Size(192, 19);
             this.chkAutoUpdate.TabIndex = 8;
@@ -704,6 +705,7 @@
             // 
             this.tabImage.AutoScroll = true;
             this.tabImage.BackColor = System.Drawing.Color.White;
+            this.tabImage.Controls.Add(this.chkShowHiddenImages);
             this.tabImage.Controls.Add(this.btnEditEditAllExt);
             this.tabImage.Controls.Add(this.btnEditResetExt);
             this.tabImage.Controls.Add(this.btnEditEditExt);
@@ -731,9 +733,9 @@
             this.tabImage.Controls.Add(this.lblSlideshowInterval);
             this.tabImage.Controls.Add(this.chkFindChildFolder);
             this.tabImage.Location = new System.Drawing.Point(4, 27);
-            this.tabImage.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.tabImage.Margin = new System.Windows.Forms.Padding(2);
             this.tabImage.Name = "tabImage";
-            this.tabImage.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.tabImage.Padding = new System.Windows.Forms.Padding(2);
             this.tabImage.Size = new System.Drawing.Size(463, 368);
             this.tabImage.TabIndex = 3;
             this.tabImage.Text = "Image";
@@ -742,8 +744,8 @@
             // 
             this.btnEditEditAllExt.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnEditEditAllExt.AutoSize = true;
-            this.btnEditEditAllExt.Location = new System.Drawing.Point(289, 837);
-            this.btnEditEditAllExt.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.btnEditEditAllExt.Location = new System.Drawing.Point(272, 858);
+            this.btnEditEditAllExt.Margin = new System.Windows.Forms.Padding(2);
             this.btnEditEditAllExt.Name = "btnEditEditAllExt";
             this.btnEditEditAllExt.Size = new System.Drawing.Size(146, 25);
             this.btnEditEditAllExt.TabIndex = 47;
@@ -754,8 +756,8 @@
             // btnEditResetExt
             // 
             this.btnEditResetExt.AutoSize = true;
-            this.btnEditResetExt.Location = new System.Drawing.Point(84, 837);
-            this.btnEditResetExt.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.btnEditResetExt.Location = new System.Drawing.Point(84, 858);
+            this.btnEditResetExt.Margin = new System.Windows.Forms.Padding(2);
             this.btnEditResetExt.Name = "btnEditResetExt";
             this.btnEditResetExt.Size = new System.Drawing.Size(133, 25);
             this.btnEditResetExt.TabIndex = 26;
@@ -767,8 +769,8 @@
             // 
             this.btnEditEditExt.AutoSize = true;
             this.btnEditEditExt.Enabled = false;
-            this.btnEditEditExt.Location = new System.Drawing.Point(30, 837);
-            this.btnEditEditExt.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.btnEditEditExt.Location = new System.Drawing.Point(30, 858);
+            this.btnEditEditExt.Margin = new System.Windows.Forms.Padding(2);
             this.btnEditEditExt.Name = "btnEditEditExt";
             this.btnEditEditExt.Size = new System.Drawing.Size(50, 25);
             this.btnEditEditExt.TabIndex = 25;
@@ -779,7 +781,7 @@
             // panel3
             // 
             this.panel3.Location = new System.Drawing.Point(18, 869);
-            this.panel3.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.panel3.Margin = new System.Windows.Forms.Padding(1);
             this.panel3.Name = "panel3";
             this.panel3.Size = new System.Drawing.Size(73, 21);
             this.panel3.TabIndex = 46;
@@ -803,13 +805,13 @@
             listViewItem1,
             listViewItem2,
             listViewItem3});
-            this.lvImageEditing.Location = new System.Drawing.Point(30, 637);
-            this.lvImageEditing.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.lvImageEditing.Location = new System.Drawing.Point(30, 658);
+            this.lvImageEditing.Margin = new System.Windows.Forms.Padding(2);
             this.lvImageEditing.MultiSelect = false;
             this.lvImageEditing.Name = "lvImageEditing";
             this.lvImageEditing.RightToLeftLayout = true;
             this.lvImageEditing.ShowItemToolTips = true;
-            this.lvImageEditing.Size = new System.Drawing.Size(405, 191);
+            this.lvImageEditing.Size = new System.Drawing.Size(388, 191);
             this.lvImageEditing.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.lvImageEditing.TabIndex = 24;
             this.lvImageEditing.UseCompatibleStateImageBehavior = false;
@@ -840,7 +842,7 @@
             // 
             this.lblHeadImageEditing.AutoSize = true;
             this.lblHeadImageEditing.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadImageEditing.Location = new System.Drawing.Point(15, 615);
+            this.lblHeadImageEditing.Location = new System.Drawing.Point(15, 636);
             this.lblHeadImageEditing.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblHeadImageEditing.Name = "lblHeadImageEditing";
             this.lblHeadImageEditing.Size = new System.Drawing.Size(84, 15);
@@ -851,7 +853,7 @@
             // 
             this.lblHeadZooming.AutoSize = true;
             this.lblHeadZooming.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadZooming.Location = new System.Drawing.Point(15, 181);
+            this.lblHeadZooming.Location = new System.Drawing.Point(15, 202);
             this.lblHeadZooming.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblHeadZooming.Name = "lblHeadZooming";
             this.lblHeadZooming.Size = new System.Drawing.Size(56, 15);
@@ -862,7 +864,7 @@
             // 
             this.lblHeadSlideshow.AutoSize = true;
             this.lblHeadSlideshow.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadSlideshow.Location = new System.Drawing.Point(15, 493);
+            this.lblHeadSlideshow.Location = new System.Drawing.Point(15, 514);
             this.lblHeadSlideshow.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblHeadSlideshow.Name = "lblHeadSlideshow";
             this.lblHeadSlideshow.Size = new System.Drawing.Size(63, 15);
@@ -873,7 +875,7 @@
             // 
             this.lblHeadThumbnailBar.AutoSize = true;
             this.lblHeadThumbnailBar.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadThumbnailBar.Location = new System.Drawing.Point(15, 309);
+            this.lblHeadThumbnailBar.Location = new System.Drawing.Point(15, 330);
             this.lblHeadThumbnailBar.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblHeadThumbnailBar.Name = "lblHeadThumbnailBar";
             this.lblHeadThumbnailBar.Size = new System.Drawing.Size(86, 15);
@@ -894,8 +896,8 @@
             // chkLoopViewer
             // 
             this.chkLoopViewer.AutoSize = true;
-            this.chkLoopViewer.Location = new System.Drawing.Point(30, 57);
-            this.chkLoopViewer.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkLoopViewer.Location = new System.Drawing.Point(30, 78);
+            this.chkLoopViewer.Margin = new System.Windows.Forms.Padding(1);
             this.chkLoopViewer.Name = "chkLoopViewer";
             this.chkLoopViewer.Size = new System.Drawing.Size(387, 19);
             this.chkLoopViewer.TabIndex = 14;
@@ -905,8 +907,8 @@
             // chkMouseNavigation
             // 
             this.chkMouseNavigation.AutoSize = true;
-            this.chkMouseNavigation.Location = new System.Drawing.Point(30, 203);
-            this.chkMouseNavigation.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkMouseNavigation.Location = new System.Drawing.Point(30, 224);
+            this.chkMouseNavigation.Margin = new System.Windows.Forms.Padding(1);
             this.chkMouseNavigation.Name = "chkMouseNavigation";
             this.chkMouseNavigation.Size = new System.Drawing.Size(366, 19);
             this.chkMouseNavigation.TabIndex = 17;
@@ -916,7 +918,7 @@
             // lblGeneral_ZoomOptimization
             // 
             this.lblGeneral_ZoomOptimization.AutoSize = true;
-            this.lblGeneral_ZoomOptimization.Location = new System.Drawing.Point(27, 236);
+            this.lblGeneral_ZoomOptimization.Location = new System.Drawing.Point(27, 257);
             this.lblGeneral_ZoomOptimization.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblGeneral_ZoomOptimization.Name = "lblGeneral_ZoomOptimization";
             this.lblGeneral_ZoomOptimization.Size = new System.Drawing.Size(109, 15);
@@ -929,8 +931,8 @@
             this.cmbZoomOptimization.FormattingEnabled = true;
             this.cmbZoomOptimization.Items.AddRange(new object[] {
             "(loaded from code)"});
-            this.cmbZoomOptimization.Location = new System.Drawing.Point(30, 254);
-            this.cmbZoomOptimization.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.cmbZoomOptimization.Location = new System.Drawing.Point(30, 275);
+            this.cmbZoomOptimization.Margin = new System.Windows.Forms.Padding(1);
             this.cmbZoomOptimization.Name = "cmbZoomOptimization";
             this.cmbZoomOptimization.Size = new System.Drawing.Size(187, 23);
             this.cmbZoomOptimization.TabIndex = 18;
@@ -938,8 +940,8 @@
             // chkThumbnailVertical
             // 
             this.chkThumbnailVertical.AutoSize = true;
-            this.chkThumbnailVertical.Location = new System.Drawing.Point(30, 331);
-            this.chkThumbnailVertical.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkThumbnailVertical.Location = new System.Drawing.Point(30, 352);
+            this.chkThumbnailVertical.Margin = new System.Windows.Forms.Padding(1);
             this.chkThumbnailVertical.Name = "chkThumbnailVertical";
             this.chkThumbnailVertical.Size = new System.Drawing.Size(173, 19);
             this.chkThumbnailVertical.TabIndex = 19;
@@ -949,7 +951,7 @@
             // lblGeneral_ThumbnailSize
             // 
             this.lblGeneral_ThumbnailSize.AutoSize = true;
-            this.lblGeneral_ThumbnailSize.Location = new System.Drawing.Point(27, 419);
+            this.lblGeneral_ThumbnailSize.Location = new System.Drawing.Point(27, 440);
             this.lblGeneral_ThumbnailSize.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblGeneral_ThumbnailSize.Name = "lblGeneral_ThumbnailSize";
             this.lblGeneral_ThumbnailSize.Size = new System.Drawing.Size(175, 15);
@@ -969,8 +971,8 @@
             "256",
             "512",
             "1024"});
-            this.cmbThumbnailDimension.Location = new System.Drawing.Point(30, 437);
-            this.cmbThumbnailDimension.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.cmbThumbnailDimension.Location = new System.Drawing.Point(30, 458);
+            this.cmbThumbnailDimension.Margin = new System.Windows.Forms.Padding(1);
             this.cmbThumbnailDimension.Name = "cmbThumbnailDimension";
             this.cmbThumbnailDimension.Size = new System.Drawing.Size(187, 23);
             this.cmbThumbnailDimension.TabIndex = 21;
@@ -978,8 +980,8 @@
             // chkImageBoosterBack
             // 
             this.chkImageBoosterBack.AutoSize = true;
-            this.chkImageBoosterBack.Location = new System.Drawing.Point(30, 79);
-            this.chkImageBoosterBack.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkImageBoosterBack.Location = new System.Drawing.Point(30, 100);
+            this.chkImageBoosterBack.Margin = new System.Windows.Forms.Padding(1);
             this.chkImageBoosterBack.Name = "chkImageBoosterBack";
             this.chkImageBoosterBack.Size = new System.Drawing.Size(385, 19);
             this.chkImageBoosterBack.TabIndex = 15;
@@ -989,8 +991,8 @@
             // chkLoopSlideshow
             // 
             this.chkLoopSlideshow.AutoSize = true;
-            this.chkLoopSlideshow.Location = new System.Drawing.Point(30, 515);
-            this.chkLoopSlideshow.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkLoopSlideshow.Location = new System.Drawing.Point(30, 536);
+            this.chkLoopSlideshow.Margin = new System.Windows.Forms.Padding(1);
             this.chkLoopSlideshow.Name = "chkLoopSlideshow";
             this.chkLoopSlideshow.Size = new System.Drawing.Size(405, 19);
             this.chkLoopSlideshow.TabIndex = 22;
@@ -999,8 +1001,8 @@
             // 
             // numMaxThumbSize
             // 
-            this.numMaxThumbSize.Location = new System.Drawing.Point(30, 383);
-            this.numMaxThumbSize.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.numMaxThumbSize.Location = new System.Drawing.Point(30, 404);
+            this.numMaxThumbSize.Margin = new System.Windows.Forms.Padding(1);
             this.numMaxThumbSize.Maximum = new decimal(new int[] {
             30,
             0,
@@ -1024,7 +1026,7 @@
             // lblGeneral_MaxFileSize
             // 
             this.lblGeneral_MaxFileSize.AutoSize = true;
-            this.lblGeneral_MaxFileSize.Location = new System.Drawing.Point(27, 364);
+            this.lblGeneral_MaxFileSize.Location = new System.Drawing.Point(27, 385);
             this.lblGeneral_MaxFileSize.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblGeneral_MaxFileSize.Name = "lblGeneral_MaxFileSize";
             this.lblGeneral_MaxFileSize.Size = new System.Drawing.Size(186, 15);
@@ -1034,7 +1036,7 @@
             // lblImageLoadingOrder
             // 
             this.lblImageLoadingOrder.AutoSize = true;
-            this.lblImageLoadingOrder.Location = new System.Drawing.Point(27, 110);
+            this.lblImageLoadingOrder.Location = new System.Drawing.Point(27, 131);
             this.lblImageLoadingOrder.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblImageLoadingOrder.Name = "lblImageLoadingOrder";
             this.lblImageLoadingOrder.Size = new System.Drawing.Size(117, 15);
@@ -1053,8 +1055,8 @@
             "Last write time",
             "Extension",
             "Random"});
-            this.cmbImageOrder.Location = new System.Drawing.Point(30, 127);
-            this.cmbImageOrder.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.cmbImageOrder.Location = new System.Drawing.Point(30, 148);
+            this.cmbImageOrder.Margin = new System.Windows.Forms.Padding(1);
             this.cmbImageOrder.Name = "cmbImageOrder";
             this.cmbImageOrder.Size = new System.Drawing.Size(187, 23);
             this.cmbImageOrder.TabIndex = 16;
@@ -1062,8 +1064,8 @@
             // barInterval
             // 
             this.barInterval.BackColor = System.Drawing.SystemColors.Window;
-            this.barInterval.Location = new System.Drawing.Point(30, 568);
-            this.barInterval.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.barInterval.Location = new System.Drawing.Point(30, 589);
+            this.barInterval.Margin = new System.Windows.Forms.Padding(1);
             this.barInterval.Maximum = 60;
             this.barInterval.Minimum = 1;
             this.barInterval.Name = "barInterval";
@@ -1076,7 +1078,7 @@
             // lblSlideshowInterval
             // 
             this.lblSlideshowInterval.AutoSize = true;
-            this.lblSlideshowInterval.Location = new System.Drawing.Point(27, 547);
+            this.lblSlideshowInterval.Location = new System.Drawing.Point(27, 568);
             this.lblSlideshowInterval.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblSlideshowInterval.Name = "lblSlideshowInterval";
             this.lblSlideshowInterval.Size = new System.Drawing.Size(163, 15);
@@ -1087,7 +1089,7 @@
             // 
             this.chkFindChildFolder.AutoSize = true;
             this.chkFindChildFolder.Location = new System.Drawing.Point(30, 35);
-            this.chkFindChildFolder.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.chkFindChildFolder.Margin = new System.Windows.Forms.Padding(1);
             this.chkFindChildFolder.Name = "chkFindChildFolder";
             this.chkFindChildFolder.Size = new System.Drawing.Size(166, 19);
             this.chkFindChildFolder.TabIndex = 13;
@@ -1104,7 +1106,7 @@
             // 
             this.sp1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.sp1.Location = new System.Drawing.Point(1, 1);
-            this.sp1.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.sp1.Margin = new System.Windows.Forms.Padding(1);
             this.sp1.Name = "sp1";
             // 
             // sp1.Panel1
@@ -1231,6 +1233,17 @@
             this.panel4.Size = new System.Drawing.Size(625, 48);
             this.panel4.TabIndex = 18;
             // 
+            // chkShowHiddenImages
+            // 
+            this.chkShowHiddenImages.AutoSize = true;
+            this.chkShowHiddenImages.Location = new System.Drawing.Point(30, 57);
+            this.chkShowHiddenImages.Margin = new System.Windows.Forms.Padding(1);
+            this.chkShowHiddenImages.Name = "chkShowHiddenImages";
+            this.chkShowHiddenImages.Size = new System.Drawing.Size(136, 19);
+            this.chkShowHiddenImages.TabIndex = 48;
+            this.chkShowHiddenImages.Text = "Show hidden images";
+            this.chkShowHiddenImages.UseVisualStyleBackColor = true;
+            // 
             // frmSetting
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -1241,7 +1254,7 @@
             this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.KeyPreview = true;
-            this.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+            this.Margin = new System.Windows.Forms.Padding(1);
             this.MinimumSize = new System.Drawing.Size(470, 368);
             this.Name = "frmSetting";
             this.RightToLeftLayout = true;
@@ -1360,5 +1373,6 @@
         private System.Windows.Forms.TableLayoutPanel tblayout;
         private System.Windows.Forms.Panel panel4;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.CheckBox chkShowHiddenImages;
     }
 }

--- a/Source/ImageGlass/frmSetting.cs
+++ b/Source/ImageGlass/frmSetting.cs
@@ -235,6 +235,7 @@ namespace ImageGlass
             //Image tab
             lblHeadImageLoading.Text = GlobalSetting.LangPack.Items["frmSetting.lblHeadImageLoading"];//
             chkFindChildFolder.Text = GlobalSetting.LangPack.Items["frmSetting.chkFindChildFolder"];
+            chkShowHiddenImages.Text = GlobalSetting.LangPack.Items["frmSetting.chkShowHiddenImages"];
             chkLoopViewer.Text = GlobalSetting.LangPack.Items["frmSetting.chkLoopViewer"];
             chkImageBoosterBack.Text = GlobalSetting.LangPack.Items["frmSetting.chkImageBoosterBack"];
             lblImageLoadingOrder.Text = GlobalSetting.LangPack.Items["frmSetting.lblImageLoadingOrder"];
@@ -437,7 +438,10 @@ namespace ImageGlass
         private void LoadTabImageConfig()
         {
             //Get value of chkFindChildFolder ---------------------------------------------
-            chkFindChildFolder.Checked = GlobalSetting.IsRecursiveLoading;            
+            chkFindChildFolder.Checked = GlobalSetting.IsRecursiveLoading;
+
+            //Get value of chkShowHiddenImages
+            chkShowHiddenImages.Checked = GlobalSetting.IsShowingHiddenImages;
 
             //Get value of chkLoopViewer
             chkLoopViewer.Checked = GlobalSetting.IsLoopBackViewer;
@@ -967,6 +971,10 @@ namespace ImageGlass
             //IsRecursiveLoading
             GlobalSetting.IsRecursiveLoading = chkFindChildFolder.Checked;
             GlobalSetting.SetConfig("IsRecursiveLoading", GlobalSetting.IsRecursiveLoading.ToString());
+
+            //IsShowingHiddenImages
+            GlobalSetting.IsShowingHiddenImages = chkShowHiddenImages.Checked;
+            GlobalSetting.SetConfig("IsShowingHiddenImages", GlobalSetting.IsShowingHiddenImages.ToString());
 
             //IsLoopBackViewer
             GlobalSetting.IsLoopBackViewer = chkLoopViewer.Checked;


### PR DESCRIPTION
Added settings checkbox that toggles filter for hidden images as per issue #187. 

When this setting is off hidden images will not be added to image list, thus not displayed in thumbnail bar or when using arrow keys or buttons.

![setting_hidden](https://user-images.githubusercontent.com/27233632/31194302-6277a1f2-a94f-11e7-99d8-47e9719833d4.PNG)

Possible future improvement/addition could be hiding images where the filename starts with . (dotfiles).