### PR TITLE
Fix default wallpaper mode (Issue #247)

### DIFF
--- a/Source/Components/ImageGlass.Library/Image/DesktopWallapaper.cs
+++ b/Source/Components/ImageGlass.Library/Image/DesktopWallapaper.cs
@@ -36,6 +36,10 @@ namespace ImageGlass.Library.Image
         public enum Style : int
         {
             /// <summary>
+            /// Current windows wallpaper style
+            /// </summary>
+            Current = -1,
+            /// <summary>
             /// 0
             /// </summary>
             Centered = 0,

--- a/Source/Ultilities/igtasks/Program.cs
+++ b/Source/Ultilities/igtasks/Program.cs
@@ -79,7 +79,7 @@ namespace adtasks
                     }
                     else //style == "0"
                     {
-                        DesktopWallapaper.Set(new Uri(imgPath), DesktopWallapaper.Style.Centered);
+                        DesktopWallapaper.Set(new Uri(imgPath), DesktopWallapaper.Style.Current);
                     }
                 }
                 else


### PR DESCRIPTION
Fix for #247 where changing wallpaper always defaults to a hardcoded mode. Now current windows wallpaper setting is retained when setting image as wallpaper