### PR TITLE
Fix hamburger button disappearing (Issue #214)

### DIFF
--- a/Source/ImageGlass/frmMain.Designer.cs
+++ b/Source/ImageGlass/frmMain.Designer.cs
@@ -223,6 +223,7 @@
             this.toolMain.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
             this.toolMain.Size = new System.Drawing.Size(920, 60);
             this.toolMain.TabIndex = 1;
+            this.toolMain.SizeChanged += new System.EventHandler(this.toolMain_SizeChanged);
             // 
             // btnBack
             // 
@@ -610,6 +611,7 @@
             this.btnMenu.ShowDropDownArrow = false;
             this.btnMenu.Size = new System.Drawing.Size(33, 33);
             this.btnMenu.Text = "Menu (Hotkey: `)";
+            this.btnMenu.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             // 
             // mnuMain
             // 

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -1937,7 +1937,19 @@ namespace ImageGlass
                     break;
             }
         }
-        
+
+        private void toolMain_SizeChanged(object sender, EventArgs e)
+        {
+            if (toolMain.PreferredSize.Width > toolMain.Size.Width)
+            {
+                btnMenu.Alignment = ToolStripItemAlignment.Left;
+            }
+            else
+            {
+                btnMenu.Alignment = ToolStripItemAlignment.Right;
+            }
+        }
+
         #endregion
 
 


### PR DESCRIPTION
Hamburger button will now remain visible even if toolbar is not big enough to accommodate other buttons (Issue #214)

![toolbar](https://user-images.githubusercontent.com/27233632/31337706-3483359a-ad05-11e7-87be-6b1d8cf95703.png)

The size changed event is used to change hamburger's alignment to left if there is not enough space. Otherwise "show more" dialog will also show weird empty space

Known issue: pressing "show more" button shows light background still making icons hard to see