### PR TITLE
Decrease startup delay by using lazy initialization

### DIFF
--- a/Source/ImageGlass/LocalSetting.cs
+++ b/Source/ImageGlass/LocalSetting.cs
@@ -17,17 +17,18 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System.Threading;
 
 namespace ImageGlass
 {
     public static class LocalSetting
     {
-        private static frmFacebook _fFacebook = new frmFacebook();
-        private static frmSetting _fSetting = new frmSetting();
-        private static frmExtension _fExtension = new frmExtension();
+        private static frmFacebook _fFacebook;
+        private static frmSetting _fSetting;
+        private static frmExtension _fExtension;
         private static string _imageModifiedPath = "";
         private static bool _isResetScrollPosition = true;
-        private static Theme.Theme _theme = new Theme.Theme();
+        private static Theme.Theme _theme;
         private static bool _isThumbnailDimensionChanged = false;
 
         #region "Properties"
@@ -36,7 +37,7 @@ namespace ImageGlass
         /// </summary>
         public static frmFacebook FFacebook
         {
-            get { return _fFacebook; }
+            get { return LazyInitializer.EnsureInitialized(ref _fFacebook); }
             set { _fFacebook = value; }
         }
 
@@ -45,7 +46,7 @@ namespace ImageGlass
         /// </summary>
         public static frmSetting FSetting
         {
-            get { return _fSetting; }
+            get { return LazyInitializer.EnsureInitialized(ref _fSetting); }
             set { _fSetting = value; }
         }
 
@@ -54,7 +55,7 @@ namespace ImageGlass
         /// </summary>
         public static frmExtension FExtension
         {
-            get { return _fExtension; }
+            get { return LazyInitializer.EnsureInitialized(ref _fExtension); }
             set { _fExtension = value; }
         }
 
@@ -88,7 +89,7 @@ namespace ImageGlass
         /// <summary>
         /// Gets, sets current app theme
         /// </summary>
-        public static Theme.Theme Theme { get => _theme; set => _theme = value; }
+        public static Theme.Theme Theme { get => LazyInitializer.EnsureInitialized(ref _theme, () => new Theme.Theme()); set => _theme = value; }
 
         /// <summary>
         /// Gets, sets the value that will request frmMain to update thumbnail bar


### PR DESCRIPTION
The LocalSettings.IsResetScrollPosition property is read during
construction of the main form. This forces the LocalSettings class
to be initialized. Because the LocalSettings class contains
non-trivial members, this takes a considerable amount of time.

However, the non-trivial members in LocalSettings are not used
during initial startup, so by changing them to be initialized lazily
a considerable startup delay (roughly one second on my machine) can
be avoided.