### PR TITLE
Move arrow key image navigation from KeyUp to KeyDown for better responsiveness

### DIFF
--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -1035,7 +1035,7 @@ namespace ImageGlass
 
             //Previous Image----------------------------------------------------------------
             #region LEFT ARROW / PAGE UP
-            if (!_isWindowsKeyPressed && (e.KeyValue == 33 || e.KeyValue == 37) &&
+            if (!_isWindowsKeyPressed && !_isAppBusy && (e.KeyValue == 33 || e.KeyValue == 37) &&
                 !e.Control && !e.Shift && !e.Alt)//Left arrow / PageUp
             {
                 NextPic(-1);
@@ -1046,7 +1046,7 @@ namespace ImageGlass
 
             //Next Image---------------------------------------------------------------------
             #region RIGHT ARROW / PAGE DOWN
-            if (!_isWindowsKeyPressed && (e.KeyValue == 34 || e.KeyValue == 39) &&
+            if (!_isWindowsKeyPressed && !_isAppBusy && (e.KeyValue == 34 || e.KeyValue == 39) &&
                 !e.Control && !e.Shift && !e.Alt)//Right arrow / Pagedown
             {
                 NextPic(1);

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -1032,24 +1032,6 @@ namespace ImageGlass
             }
             #endregion
 
-            
-        }
-        
-        private void frmMain_KeyUp(object sender, KeyEventArgs e)
-        {
-            //this.Text = e.KeyValue.ToString();
-
-            //Ctrl---------------------------------------------------------------------------
-            #region CTRL (for Zooming)
-            if (e.KeyData == Keys.ControlKey && !e.Alt && !e.Shift)//Ctrl
-            {
-                //Disable dragging viewing image to desktop feature--------------------------
-                _isDraggingImage = false;
-                
-                return;
-            }
-            #endregion
-            
 
             //Previous Image----------------------------------------------------------------
             #region LEFT ARROW / PAGE UP
@@ -1094,6 +1076,22 @@ namespace ImageGlass
             }
             #endregion
 
+        }
+
+        private void frmMain_KeyUp(object sender, KeyEventArgs e)
+        {
+            //this.Text = e.KeyValue.ToString();
+
+            //Ctrl---------------------------------------------------------------------------
+            #region CTRL (for Zooming)
+            if (e.KeyData == Keys.ControlKey && !e.Alt && !e.Shift)//Ctrl
+            {
+                //Disable dragging viewing image to desktop feature--------------------------
+                _isDraggingImage = false;
+                
+                return;
+            }
+            #endregion
 
             //Start / stop slideshow---------------------------------------------------------
             #region SPACE


### PR DESCRIPTION
This pull request moves the code that changes the image when the left/right arrow keys are pressed from `frmMain_KeyUp()` to `frmMain_KeyDown()`. This means that the new image will start loading as soon as the key is down, which leads to snappier performance.

As an added bonus, the user can now hold down the left/right arrow key to quickly browse through all the images.