### PR TITLE
Fix main project's pre- and post-build scripts

### DIFF
--- a/Source/ImageGlass/ImageGlass.csproj
+++ b/Source/ImageGlass/ImageGlass.csproj
@@ -361,10 +361,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>"$(DevEnvDir)\devenv" "$(SolutionDir)\ImageGlass.sln" /Build /Project "$(SolutionDir)\Ultilities\igcmdWin10\igcmdWin10.csproj"</PreBuildEvent>
+    <PreBuildEvent>"$(DevEnvDir)\devenv" "$(SolutionDir)\ImageGlass.sln" /Build $(ConfigurationName) /Project "$(SolutionDir)\Ultilities\igcmdWin10\igcmdWin10.csproj"</PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>resources.bat</PostBuildEvent>
+    <PostBuildEvent>resources.bat $(SolutionDir)</PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/Source/ImageGlass/resources.bat
+++ b/Source/ImageGlass/resources.bat
@@ -1,25 +1,24 @@
+echo "1: %1"
+echo "CD: %CD%"
 
-:: if Platform is X64
-IF NOT EXIST ..\..\..\Ultilities\igcmdWin10\bin\Release\ (
-	xcopy /Q /K /D /H /Y ..\..\..\..\Ultilities\igcmdWin10\bin\Release\*.* .\
+set SOLUTION_DIR=%1
+set OUTPUT_DIR=%CD%
+set IGCMD_DIR=%OUTPUT_DIR:\ImageGlass\bin\=\Ultilities\igcmdWin10\bin\%
+set THEME_DIR=%SOLUTION_DIR%..\Setup\Assets\DefaultTheme
 
-) ELSE (
-    :: Platform is AnyCPU
-	xcopy /Q /K /D /H /Y ..\..\..\Ultilities\igcmdWin10\bin\Release\*.* .\
-)
+echo SOLUTION_DIR: %SOLUTION_DIR%
+echo OUTPUT_DIR: %OUTPUT_DIR%
+echo IGCMD_DIR: %IGCMD_DIR%
+echo THEME_DIR: %THEME_DIR%
 
+echo Copy from %IGCMD_DIR%
+xcopy /Q /K /D /H /Y %IGCMD_DIR%\*.* .\
 
 IF NOT EXIST DefaultTheme\ (
 
 	mkdir DefaultTheme
+	echo Copy from %THEME_DIR%
+	xcopy /Q /K /D /H /Y %THEME_DIR%\*.* DefaultTheme
 
-	:: if Platform is X64
-	IF NOT EXIST ..\..\..\..\Assets\Setup\DefaultTheme\ (
-		xcopy /Q /K /D /H /Y ..\..\..\..\..\Assets\Setup\DefaultTheme\*.* DefaultTheme
-	
-	) ELSE (
-	:: Platform is AnyCPU
-		xcopy /Q /K /D /H /Y ..\..\..\..\Assets\Setup\DefaultTheme\*.* DefaultTheme
-	)
 )
 


### PR DESCRIPTION
Pass current configuration name to the igcmdWin10 build command. Use full solution path and current bin path to copy files. Fix DefaultTheme assets path: "Assets\Setup\DefaultTheme" -> "Setup\Assets\DefaultTheme".