### PR TITLE
Feature/issue552

### DIFF
--- a/Source/Components/ImageGlass.UI/Theme.cs
+++ b/Source/Components/ImageGlass.UI/Theme.cs
@@ -228,7 +228,7 @@ namespace ImageGlass.UI
             ToolbarIcons.RotateRight.Refresh();
             ToolbarIcons.FlipHorz.Refresh();
             ToolbarIcons.FlipVert.Refresh();
-            ToolbarIcons.Detele.Refresh();
+            ToolbarIcons.Delete.Refresh();
             ToolbarIcons.Edit.Refresh();
             ToolbarIcons.ZoomIn.Refresh();
             ToolbarIcons.ZoomOut.Refresh();
@@ -464,7 +464,7 @@ namespace ImageGlass.UI
             ToolbarIcons.RotateRight = LoadThemeImage(dir, n, "rightrotate");
             ToolbarIcons.FlipHorz = LoadThemeImage(dir, n, "fliphorz");
             ToolbarIcons.FlipVert = LoadThemeImage(dir, n, "flipvert");
-            ToolbarIcons.Detele = LoadThemeImage(dir, n, "delete");
+            ToolbarIcons.Delete = LoadThemeImage(dir, n, "delete");
             ToolbarIcons.Edit = LoadThemeImage(dir, n, "edit");
             ToolbarIcons.ZoomIn = LoadThemeImage(dir, n, "zoomin");
             ToolbarIcons.ZoomOut = LoadThemeImage(dir, n, "zoomout");
@@ -555,7 +555,7 @@ namespace ImageGlass.UI
             n.SetAttribute("rightrotate", Path.GetFileName(ToolbarIcons.RotateRight.Filename));
             n.SetAttribute("fliphorz", Path.GetFileName(ToolbarIcons.FlipHorz.Filename));
             n.SetAttribute("flipvert", Path.GetFileName(ToolbarIcons.FlipVert.Filename));
-            n.SetAttribute("delete", Path.GetFileName(ToolbarIcons.Detele.Filename));
+            n.SetAttribute("delete", Path.GetFileName(ToolbarIcons.Delete.Filename));
             n.SetAttribute("edit", Path.GetFileName(ToolbarIcons.Edit.Filename));
             n.SetAttribute("zoomin", Path.GetFileName(ToolbarIcons.ZoomIn.Filename));
             n.SetAttribute("zoomout", Path.GetFileName(ToolbarIcons.ZoomOut.Filename));

--- a/Source/Components/ImageGlass.UI/Theme.cs
+++ b/Source/Components/ImageGlass.UI/Theme.cs
@@ -147,6 +147,12 @@ namespace ImageGlass.UI
         /// </summary>
         public Color MenuTextColor { get; set; } = Color.Black;
 
+
+        /// <summary>
+        /// The multiplier which impacts the size of the navigation arrows.
+        /// </summary>
+        public double NavArrowMultiplier { get; set; } = 2.0;
+
         #endregion
 
 
@@ -258,7 +264,8 @@ namespace ImageGlass.UI
 
             #region Arrow cursors (derived from toolbar)
 
-            var arrowHeight = DPIScaling.TransformNumber(Constants.TOOLBAR_ICON_HEIGHT) * 2;
+            var arrowHeight = (int)(DPIScaling.TransformNumber(Constants.TOOLBAR_ICON_HEIGHT) * NavArrowMultiplier);
+
             var prevImage = new ThemeImage(ToolbarIcons.ViewPreviousImage.Filename, arrowHeight);
             var icon = prevImage.Image.GetHicon();
             PreviousArrowCursor = new Cursor(icon);
@@ -449,6 +456,22 @@ namespace ImageGlass.UI
                 }
 
                 this.MenuTextColor = inputColor;
+            }
+            catch (Exception ex) { };
+
+            // For 7.6: add ability to control the size of the navigation arrows
+            // Minimum value is 1.0, default is 2.0.
+            try
+            {
+                var colorString = n.GetAttribute("navarrowsize");
+                if (!string.IsNullOrWhiteSpace(colorString))
+                {
+                    if (!double.TryParse(colorString, out var val))
+                        val = 2.0;
+                    val = Math.Max(val, 1.0);
+
+                    NavArrowMultiplier = val;
+                }
             }
             catch (Exception ex) { };
 

--- a/Source/Components/ImageGlass.UI/Theme.cs
+++ b/Source/Components/ImageGlass.UI/Theme.cs
@@ -430,7 +430,7 @@ namespace ImageGlass.UI
 
             #region Arrow cursors (derived from toolbar)
 
-            var arrowHeight = DPIScaling.TransformNumber(Constants.TOOLBAR_ICON_HEIGHT) * 3;
+            var arrowHeight = (int)(DPIScaling.TransformNumber(Constants.TOOLBAR_ICON_HEIGHT) * NavArrowMultiplier);
             var prevImage = LoadThemeImage(dir, n, "back", arrowHeight);
             var icon = prevImage.Image.GetHicon();
             PreviousArrowCursor = new Cursor(icon);

--- a/Source/Components/ImageGlass.UI/Theme.cs
+++ b/Source/Components/ImageGlass.UI/Theme.cs
@@ -344,120 +344,32 @@ namespace ImageGlass.UI
 
             ToolbarBackgroundImage = LoadThemeImage(dir, n, "topbar");
 
-            try
-            {
-                var colorString = n.GetAttribute("topbarcolor");
-                var inputColor = ToolbarBackgroundColor;
-
-                if (IsValidHex(colorString))
-                {
-                    inputColor = ConvertHexStringToColor(colorString, true);
-                }
-                else
-                {
-                    inputColor = Color.FromArgb(255, Color.FromArgb(int.Parse(colorString)));
-                }
-
-                ToolbarBackgroundColor = inputColor;
-            }
-            catch (Exception ex) { };
+            var color = FetchColorAttribute(n, "topbarcolor");
+            if (color != Color.Transparent)
+                ToolbarBackgroundColor = color;
 
             ThumbnailBackgroundImage = LoadThemeImage(dir, n, "bottombar");
 
+            color = FetchColorAttribute(n, "bottombarcolor");
+            if (color != Color.Transparent)
+                ThumbnailBackgroundColor = color;
 
-            try
-            {
-                var colorString = n.GetAttribute("bottombarcolor");
-                var inputColor = ThumbnailBackgroundColor;
+            color = FetchColorAttribute(n, "backcolor");
+            if (color != Color.Transparent)
+                BackgroundColor = color;
 
-                if (IsValidHex(colorString))
-                {
-                    inputColor = ConvertHexStringToColor(colorString, true);
-                }
-                else
-                {
-                    inputColor = Color.FromArgb(255, Color.FromArgb(int.Parse(colorString)));
-                }
+            color = FetchColorAttribute(n, "statuscolor");
+            if (color != Color.Transparent)
+                TextInfoColor = color;
 
-                ThumbnailBackgroundColor = inputColor;
-            }
-            catch (Exception ex) { };
+            color = FetchColorAttribute(n, "menubackgroundcolor");
+            if (color != Color.Transparent)
+                MenuBackgroundColor = color;
 
+            color = FetchColorAttribute(n, "menutextcolor");
+            if (color != Color.Transparent)
+                MenuTextColor = color;
 
-            try
-            {
-                var colorString = n.GetAttribute("backcolor");
-                var inputColor = BackgroundColor;
-
-                if (IsValidHex(colorString))
-                {
-                    inputColor = ConvertHexStringToColor(colorString, true);
-                }
-                else
-                {
-                    inputColor = Color.FromArgb(255, Color.FromArgb(int.Parse(colorString)));
-                }
-
-                BackgroundColor = inputColor;
-            }
-            catch (Exception ex) { };
-
-
-            try
-            {
-                var colorString = n.GetAttribute("statuscolor");
-                var inputColor = TextInfoColor;
-
-                if (IsValidHex(colorString))
-                {
-                    inputColor = ConvertHexStringToColor(colorString, true);
-                }
-                else
-                {
-                    inputColor = Color.FromArgb(255, Color.FromArgb(int.Parse(colorString)));
-                }
-
-                TextInfoColor = inputColor;
-            }
-            catch (Exception ex) { };
-
-
-            try
-            {
-                var colorString = n.GetAttribute("menubackgroundcolor");
-                var inputColor = this.MenuBackgroundColor;
-
-                if (IsValidHex(colorString))
-                {
-                    inputColor = ConvertHexStringToColor(colorString, true);
-                }
-                else
-                {
-                    inputColor = Color.FromArgb(255, Color.FromArgb(int.Parse(colorString)));
-                }
-
-                this.MenuBackgroundColor = inputColor;
-            }
-            catch (Exception ex) { };
-
-
-            try
-            {
-                var colorString = n.GetAttribute("menutextcolor");
-                var inputColor = this.MenuTextColor;
-
-                if (IsValidHex(colorString))
-                {
-                    inputColor = ConvertHexStringToColor(colorString, true);
-                }
-                else
-                {
-                    inputColor = Color.FromArgb(255, Color.FromArgb(int.Parse(colorString)));
-                }
-
-                this.MenuTextColor = inputColor;
-            }
-            catch (Exception ex) { };
 
             // For 7.6: add ability to control the size of the navigation arrows
             // Minimum value is 1.0, default is 2.0.
@@ -532,6 +444,32 @@ namespace ImageGlass.UI
 
             this.IsValid = true;
             return this.IsValid;
+
+
+            //
+            // Fetch a color attribute value from the theme config file.
+            // Returns: a Color value if valid; Color.Transparent if an error
+            //
+            Color FetchColorAttribute(XmlElement xmlElement, string attribute)
+            {
+                try
+                {
+                    var colorString = xmlElement.GetAttribute(attribute);
+
+                    if (IsValidHex(colorString))
+                    {
+                        return ConvertHexStringToColor(colorString, true);
+                    }
+
+                    return Color.FromArgb(255, Color.FromArgb(int.Parse(colorString)));
+                }
+                catch
+                {
+                    // ignored
+                }
+
+                return Color.Transparent;
+            }
         }
 
 

--- a/Source/Components/ImageGlass.UI/ThemeIconCollection.cs
+++ b/Source/Components/ImageGlass.UI/ThemeIconCollection.cs
@@ -38,7 +38,7 @@ namespace ImageGlass.UI
         public ThemeImage RotateRight { get; set; } = new ThemeImage();
         public ThemeImage FlipHorz { get; set; } = new ThemeImage();
         public ThemeImage FlipVert { get; set; } = new ThemeImage();
-        public ThemeImage Detele { get; set; } = new ThemeImage();
+        public ThemeImage Delete { get; set; } = new ThemeImage();
         public ThemeImage Edit { get; set; } = new ThemeImage();
         public ThemeImage ScaleToHeight { get; set; } = new ThemeImage();
         public ThemeImage ScaleToWidth { get; set; } = new ThemeImage();

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -2472,7 +2472,7 @@ namespace ImageGlass
             btnRotateRight.Image = th.ToolbarIcons.RotateRight.Image;
             btnFlipHorz.Image = th.ToolbarIcons.FlipHorz.Image;
             btnFlipVert.Image = th.ToolbarIcons.FlipVert.Image;
-            btnDelete.Image = th.ToolbarIcons.Detele.Image;
+            btnDelete.Image = th.ToolbarIcons.Delete.Image;
             btnEdit.Image = th.ToolbarIcons.Edit.Image;
 
             btnZoomIn.Image = th.ToolbarIcons.ZoomIn.Image;

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -2044,8 +2044,9 @@ namespace ImageGlass
         {
             if (Local.ImageList.Length > 1)
             {
-                // calculate icon height
-                var iconHeight = DPIScaling.TransformNumber((int)Constants.TOOLBAR_ICON_HEIGHT * 3);
+                // Related to issue #552: use actual size of cursor, not a constant
+                var curse = Configs.Theme.NextArrowCursor;
+                var iconHeight = curse.Size.Height;
 
                 // get the hotpot area width
                 var hotpotWidth = Math.Max(iconHeight, picMain.Width / 7);


### PR DESCRIPTION
Address issue #552 by adding a new (optional) attribute to the theme config file. The new attribute is a double value which controls the size of the navigation arrows (relative to the toolbar arrow size).

Includes a couple of code cleanup items which could be skipped if desired.

An example using the  2017 (Light Gray) theme: the new attribute (`navarrowsize`) in the theme config.xml has been set to 1.5x instead of the default 2x:
```
<main topbar="" topbarcolor="#EAEAF2"  bottombar="" bottombarcolor="#EAEAF2" 
            backcolor="#FFFFFF" statuscolor="#000000" navarrowsize="1.5" />
```