### PR TITLE
Issue #836. Issue #634. Near the edge of the screen, the toolbar tool…

### DIFF
--- a/Source/Components/ImageGlass.Settings/Configs.cs
+++ b/Source/Components/ImageGlass.Settings/Configs.cs
@@ -253,6 +253,11 @@ namespace ImageGlass.Settings {
         /// </summary>
         public static bool IsUseTouchGesture { get; set; } = true;
 
+        /// <summary>
+        /// Gets, sets value indicates that tooltips are to be hidden
+        /// </summary>
+        public static bool IsHideTooltips { get; set; } = false;
+
         #endregion
 
         #region Number items
@@ -525,6 +530,7 @@ namespace ImageGlass.Settings {
             IsCenterWindowFit = Get<bool>(nameof(IsCenterWindowFit), IsCenterWindowFit);
             IsShowToast = Get<bool>(nameof(IsShowToast), IsShowToast);
             IsUseTouchGesture = Get<bool>(nameof(IsUseTouchGesture), IsUseTouchGesture);
+            IsHideTooltips = Get<bool>(nameof(IsHideTooltips), IsHideTooltips);
 
             #endregion
 
@@ -732,6 +738,7 @@ namespace ImageGlass.Settings {
             Set(nameof(IsCenterWindowFit), IsCenterWindowFit);
             Set(nameof(IsShowToast), IsShowToast);
             Set(nameof(IsUseTouchGesture), IsUseTouchGesture);
+            Set(nameof(IsHideTooltips), IsHideTooltips);
 
             #endregion
 

--- a/Source/Components/ImageGlass.UI/ToolStripToolTip/ToolStripToolTip.cs
+++ b/Source/Components/ImageGlass.UI/ToolStripToolTip/ToolStripToolTip.cs
@@ -47,7 +47,11 @@ namespace ImageGlass.UI {
         private ToolTip _tooltip;
         public int ToolTipInterval = 4000;
         public string ToolTipText;
-        public bool ToolTipShowUp;
+
+        /// <summary>
+        /// Gets, sets value indicates that the tooltip direction is top or bottom
+        /// </summary>
+        public bool ToolTipShowUp { get; set; } = false;
 
         private ToolbarAlignment _alignment;
 
@@ -107,10 +111,6 @@ namespace ImageGlass.UI {
             base.OnMouseLeave(e);
             timer.Stop();
             Tooltip.Hide(this);
-            // KBR 20200903 See issues #836, #634. The tooltip may start flashing if near the edge of the screen.
-            // This change seems to fix this, although I've only been able to confirm in the context of issue #634.
-            //mouseOverPoint = new Point(-50, -50);
-            //mouseOverItem = null;
         }
 
         private void timer_Tick(object sender, EventArgs e) {
@@ -118,7 +118,7 @@ namespace ImageGlass.UI {
             try {
                 Point currentMouseOverPoint;
                 if (ToolTipShowUp) {
-                    currentMouseOverPoint = this.PointToClient(new Point(Control.MousePosition.X, Control.MousePosition.Y - Cursor.Current.Size.Height + Cursor.Current.HotSpot.Y));
+                    currentMouseOverPoint = this.PointToClient(new Point(Control.MousePosition.X, Control.MousePosition.Y - Cursor.Current.Size.Height + Cursor.Current.HotSpot.Y - this.Height / 2));
                 }
                 else {
                     currentMouseOverPoint = this.PointToClient(new Point(Control.MousePosition.X, Control.MousePosition.Y + Cursor.Current.Size.Height - Cursor.Current.HotSpot.Y));
@@ -130,20 +130,13 @@ namespace ImageGlass.UI {
                     }
                 }
                 // TODO: revisit this; toolbar buttons like to disappear, if changed.
-                else if ((!(mouseOverItem is ToolStripDropDownButton) && !(mouseOverItem is ToolStripSplitButton)) ||
+                else if (((!(mouseOverItem is ToolStripDropDownButton) && !(mouseOverItem is ToolStripSplitButton)) ||
 #pragma warning disable IDE0038 // Use pattern matching
-#pragma warning disable RCS1220 // Use pattern matching instead of combination of 'is' operator and cast operator.
                     ((mouseOverItem is ToolStripDropDownButton) && !((ToolStripDropDownButton)mouseOverItem).DropDown.Visible) ||
-#pragma warning restore RCS1220 // Use pattern matching instead of combination of 'is' operator and cast operator.
 #pragma warning restore IDE0038 // Use pattern matching
 #pragma warning disable IDE0038 // Use pattern matching
-#pragma warning disable RCS1220 // Use pattern matching instead of combination of 'is' operator and cast operator.
-                    ((mouseOverItem is ToolStripSplitButton) && !((ToolStripSplitButton)mouseOverItem).DropDown.Visible)) {
-#pragma warning restore RCS1220 // Use pattern matching instead of combination of 'is' operator and cast operator.
-#pragma warning restore IDE0038 // Use pattern matching
-                    if (!string.IsNullOrEmpty(mouseOverItem.ToolTipText) && Tooltip != null) {
-                        Tooltip.Show(mouseOverItem.ToolTipText, this, currentMouseOverPoint, ToolTipInterval);
-                    }
+                    ((mouseOverItem is ToolStripSplitButton) && !((ToolStripSplitButton)mouseOverItem).DropDown.Visible)) && !string.IsNullOrEmpty(mouseOverItem.ToolTipText) && Tooltip != null) {
+                    Tooltip.Show(mouseOverItem.ToolTipText, this, currentMouseOverPoint, ToolTipInterval);
                 }
             }
             catch { }

--- a/Source/Components/ImageGlass.UI/ToolStripToolTip/ToolStripToolTip.cs
+++ b/Source/Components/ImageGlass.UI/ToolStripToolTip/ToolStripToolTip.cs
@@ -107,8 +107,10 @@ namespace ImageGlass.UI {
             base.OnMouseLeave(e);
             timer.Stop();
             Tooltip.Hide(this);
-            mouseOverPoint = new Point(-50, -50);
-            mouseOverItem = null;
+            // KBR 20200903 See issues #836, #634. The tooltip may start flashing if near the edge of the screen.
+            // This change seems to fix this, although I've only been able to confirm in the context of issue #634.
+            //mouseOverPoint = new Point(-50, -50);
+            //mouseOverItem = null;
         }
 
         private void timer_Tick(object sender, EventArgs e) {

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -3171,10 +3171,12 @@ namespace ImageGlass {
                 if (Configs.ToolbarPosition == ToolbarPosition.Top) {
                     toolMain.Anchor = AnchorStyles.Top | AnchorStyles.Left;
                     toolMain.Dock = DockStyle.Top;
+                    toolMain.ToolTipShowUp = false;
                 }
                 else if (Configs.ToolbarPosition == ToolbarPosition.Bottom) {
                     toolMain.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
                     toolMain.Dock = DockStyle.Bottom;
+                    toolMain.ToolTipShowUp = true;
                 }
 
                 // update toolbar items alignment

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -3026,48 +3026,85 @@ namespace ImageGlass {
                 #endregion
 
                 #region Toolbar
-                btnBack.ToolTipText = mnuMainViewPrevious.Text + $" ({mnuMainViewPrevious.ShortcutKeyDisplayString})";
-                btnNext.ToolTipText = mnuMainViewNext.Text + $" ({mnuMainViewNext.ShortcutKeyDisplayString})";
+                if (Configs.IsHideTooltips) {
+                    // Disable tooltips by setting the text to empty.
+                    btnBack.ToolTipText =
+                    btnNext.ToolTipText =
+                    btnRotateLeft.ToolTipText =
+                    btnRotateRight.ToolTipText =
+                    btnFlipHorz.ToolTipText =
+                    btnFlipVert.ToolTipText =
+                    btnDelete.ToolTipText =
+                    btnEdit.ToolTipText =
+                    btnCrop.ToolTipText =
+                    btnColorPicker.ToolTipText =
+                    btnZoomIn.ToolTipText =
+                    btnZoomOut.ToolTipText =
+                    btnActualSize.ToolTipText =
+                    btnAutoZoom.ToolTipText =
+                    btnScaletoWidth.ToolTipText =
+                    btnScaletoHeight.ToolTipText =
+                    btnScaleToFit.ToolTipText =
+                    btnScaleToFill.ToolTipText =
+                    btnZoomLock.ToolTipText =
+                    btnWindowFit.ToolTipText =
+                    btnFullScreen.ToolTipText =
+                    btnSlideShow.ToolTipText =
+                    btnOpen.ToolTipText =
+                    btnRefresh.ToolTipText =
+                    btnGoto.ToolTipText =
+                    btnThumb.ToolTipText =
+                    btnCheckedBackground.ToolTipText =
+                    btnConvert.ToolTipText =
+                    btnPrintImage.ToolTipText =
+                    btnMenu.ToolTipText = "";
 
-                // Edit
-                btnRotateLeft.ToolTipText = mnuMainRotateLeft.Text + $" ({mnuMainRotateLeft.ShortcutKeyDisplayString})";
-                btnRotateRight.ToolTipText = mnuMainRotateRight.Text + $" ({mnuMainRotateRight.ShortcutKeyDisplayString})";
-                btnFlipHorz.ToolTipText = mnuMainFlipHorz.Text + $" ({mnuMainFlipHorz.ShortcutKeyDisplayString})";
-                btnFlipVert.ToolTipText = mnuMainFlipVert.Text + $" ({mnuMainFlipVert.ShortcutKeyDisplayString})";
-                btnDelete.ToolTipText = mnuMainMoveToRecycleBin.Text + $" ({mnuMainMoveToRecycleBin.ShortcutKeyDisplayString})";
-                btnEdit.ToolTipText = string.Format(mnuMainEditImage.Text, "") + $" ({mnuMainEditImage.ShortcutKeyDisplayString})";
-                btnCrop.ToolTipText = string.Format(mnuMainCrop.Text, "") + $" ({mnuMainCrop.ShortcutKeyDisplayString})";
-                btnColorPicker.ToolTipText = string.Format(mnuMainColorPicker.Text, "") + $" ({mnuMainColorPicker.ShortcutKeyDisplayString})";
+                }
+                else {
+                    btnBack.ToolTipText = mnuMainViewPrevious.Text + $" ({mnuMainViewPrevious.ShortcutKeyDisplayString})";
+                    btnNext.ToolTipText = mnuMainViewNext.Text + $" ({mnuMainViewNext.ShortcutKeyDisplayString})";
 
-                // Zooming
-                btnZoomIn.ToolTipText = mnuMainZoomIn.Text + $" ({mnuMainZoomIn.ShortcutKeyDisplayString})";
-                btnZoomOut.ToolTipText = mnuMainZoomOut.Text + $" ({mnuMainZoomOut.ShortcutKeyDisplayString})";
-                btnActualSize.ToolTipText = mnuMainActualSize.Text + $" ({mnuMainActualSize.ShortcutKeyDisplayString})";
+                    // Edit
+                    btnRotateLeft.ToolTipText = mnuMainRotateLeft.Text + $" ({mnuMainRotateLeft.ShortcutKeyDisplayString})";
+                    btnRotateRight.ToolTipText = mnuMainRotateRight.Text + $" ({mnuMainRotateRight.ShortcutKeyDisplayString})";
+                    btnFlipHorz.ToolTipText = mnuMainFlipHorz.Text + $" ({mnuMainFlipHorz.ShortcutKeyDisplayString})";
+                    btnFlipVert.ToolTipText = mnuMainFlipVert.Text + $" ({mnuMainFlipVert.ShortcutKeyDisplayString})";
+                    btnDelete.ToolTipText = mnuMainMoveToRecycleBin.Text + $" ({mnuMainMoveToRecycleBin.ShortcutKeyDisplayString})";
+                    btnEdit.ToolTipText = string.Format(mnuMainEditImage.Text, "") + $" ({mnuMainEditImage.ShortcutKeyDisplayString})";
+                    btnCrop.ToolTipText = string.Format(mnuMainCrop.Text, "") + $" ({mnuMainCrop.ShortcutKeyDisplayString})";
+                    btnColorPicker.ToolTipText = string.Format(mnuMainColorPicker.Text, "") + $" ({mnuMainColorPicker.ShortcutKeyDisplayString})";
 
-                // Zoom modes
-                btnAutoZoom.ToolTipText = mnuMainAutoZoom.Text + $" ({mnuMainAutoZoom.ShortcutKeyDisplayString})";
-                btnScaletoWidth.ToolTipText = mnuMainScaleToWidth.Text + $" ({mnuMainScaleToWidth.ShortcutKeyDisplayString})";
-                btnScaletoHeight.ToolTipText = mnuMainScaleToHeight.Text + $" ({mnuMainScaleToHeight.ShortcutKeyDisplayString})";
-                btnScaleToFit.ToolTipText = mnuMainScaleToFit.Text + $" ({mnuMainScaleToFit.ShortcutKeyDisplayString})";
-                btnScaleToFill.ToolTipText = mnuMainScaleToFill.Text + $" ({mnuMainScaleToFill.ShortcutKeyDisplayString})";
-                btnZoomLock.ToolTipText = mnuMainLockZoomRatio.Text + $" ({mnuMainLockZoomRatio.ShortcutKeyDisplayString})";
+                    // Zooming
+                    btnZoomIn.ToolTipText = mnuMainZoomIn.Text + $" ({mnuMainZoomIn.ShortcutKeyDisplayString})";
+                    btnZoomOut.ToolTipText = mnuMainZoomOut.Text + $" ({mnuMainZoomOut.ShortcutKeyDisplayString})";
+                    btnActualSize.ToolTipText = mnuMainActualSize.Text + $" ({mnuMainActualSize.ShortcutKeyDisplayString})";
 
-                // Window modes
-                btnWindowFit.ToolTipText = mnuWindowFit.Text + $" ({mnuWindowFit.ShortcutKeyDisplayString})";
-                btnFullScreen.ToolTipText = mnuMainFullScreen.Text + $" ({mnuMainFullScreen.ShortcutKeyDisplayString})";
-                btnSlideShow.ToolTipText = mnuMainSlideShowStart.Text + $" ({mnuMainSlideShowStart.ShortcutKeyDisplayString})";
+                    // Zoom modes
+                    btnAutoZoom.ToolTipText = mnuMainAutoZoom.Text + $" ({mnuMainAutoZoom.ShortcutKeyDisplayString})";
+                    btnScaletoWidth.ToolTipText = mnuMainScaleToWidth.Text + $" ({mnuMainScaleToWidth.ShortcutKeyDisplayString})";
+                    btnScaletoHeight.ToolTipText = mnuMainScaleToHeight.Text + $" ({mnuMainScaleToHeight.ShortcutKeyDisplayString})";
+                    btnScaleToFit.ToolTipText = mnuMainScaleToFit.Text + $" ({mnuMainScaleToFit.ShortcutKeyDisplayString})";
+                    btnScaleToFill.ToolTipText = mnuMainScaleToFill.Text + $" ({mnuMainScaleToFill.ShortcutKeyDisplayString})";
+                    btnZoomLock.ToolTipText = mnuMainLockZoomRatio.Text + $" ({mnuMainLockZoomRatio.ShortcutKeyDisplayString})";
 
-                // File
-                btnOpen.ToolTipText = mnuMainOpenFile.Text + $" ({mnuMainOpenFile.ShortcutKeyDisplayString})";
-                btnRefresh.ToolTipText = mnuMainRefresh.Text + $" ({mnuMainRefresh.ShortcutKeyDisplayString})";
-                btnGoto.ToolTipText = mnuMainGoto.Text + $" ({mnuMainGoto.ShortcutKeyDisplayString})";
+                    // Window modes
+                    btnWindowFit.ToolTipText = mnuWindowFit.Text + $" ({mnuWindowFit.ShortcutKeyDisplayString})";
+                    btnFullScreen.ToolTipText = mnuMainFullScreen.Text + $" ({mnuMainFullScreen.ShortcutKeyDisplayString})";
+                    btnSlideShow.ToolTipText = mnuMainSlideShowStart.Text + $" ({mnuMainSlideShowStart.ShortcutKeyDisplayString})";
 
-                // Layout
-                btnThumb.ToolTipText = mnuMainThumbnailBar.Text + $" ({mnuMainThumbnailBar.ShortcutKeyDisplayString})";
-                btnCheckedBackground.ToolTipText = mnuMainCheckBackground.Text + $" ({mnuMainCheckBackground.ShortcutKeyDisplayString})";
-                btnConvert.ToolTipText = mnuMainSaveAs.Text + $" ({mnuMainSaveAs.ShortcutKeyDisplayString})";
-                btnPrintImage.ToolTipText = mnuMainPrint.Text + $" ({mnuMainPrint.ShortcutKeyDisplayString})";
-                btnMenu.ToolTipText = lang[$"{Name}.{nameof(btnMenu)}"];
+                    // File
+                    btnOpen.ToolTipText = mnuMainOpenFile.Text + $" ({mnuMainOpenFile.ShortcutKeyDisplayString})";
+                    btnRefresh.ToolTipText = mnuMainRefresh.Text + $" ({mnuMainRefresh.ShortcutKeyDisplayString})";
+                    btnGoto.ToolTipText = mnuMainGoto.Text + $" ({mnuMainGoto.ShortcutKeyDisplayString})";
+
+                    // Layout
+                    btnThumb.ToolTipText = mnuMainThumbnailBar.Text + $" ({mnuMainThumbnailBar.ShortcutKeyDisplayString})";
+                    btnCheckedBackground.ToolTipText = mnuMainCheckBackground.Text + $" ({mnuMainCheckBackground.ShortcutKeyDisplayString})";
+                    btnConvert.ToolTipText = mnuMainSaveAs.Text + $" ({mnuMainSaveAs.ShortcutKeyDisplayString})";
+                    btnPrintImage.ToolTipText = mnuMainPrint.Text + $" ({mnuMainPrint.ShortcutKeyDisplayString})";
+                    btnMenu.ToolTipText = lang[$"{Name}.{nameof(btnMenu)}"];
+
+                }
 
                 #endregion
 


### PR DESCRIPTION
…tips may 'flash'. This appears to be due to extra 'MouseLeave' events occurring.

This is a two part fix. 
1. Change ToolStripToolTip.cs : do not re-show the tooltip immediately. This appears to solve the issue, but I've only been able to confirm it with Issue #634; I cannot repro issue #836.
2. In case the fix doesn't work for issue #836, I've added a config option called "IsHideTooltips". This is _not_ exposed via the GUI as it is hopefully not needed. If set true, will disable all tooltips by setting the toolbar tooltiptext to an empty string.