### PR TITLE
Fix crash caused by pull request #849

### DIFF
--- a/Source/Components/ImageGlass.UI/Theme/Theme.cs
+++ b/Source/Components/ImageGlass.UI/Theme/Theme.cs
@@ -252,8 +252,13 @@ namespace ImageGlass.UI {
 
             var arrowHeight = (int)(DPIScaling.Transform(Constants.TOOLBAR_ICON_HEIGHT) * NavArrowMultiplier);
 
-            NavArrowLeft = new ThemeImage(ToolbarIcons.ViewPreviousImage.Filename, arrowHeight).Image;
-            NavArrowRight = new ThemeImage(ToolbarIcons.ViewNextImage.Filename, arrowHeight).Image;
+            var navArrowTemp = new ThemeImage(ToolbarIcons.ViewPreviousImage.Filename, arrowHeight);
+            navArrowTemp.Refresh();
+            NavArrowLeft = navArrowTemp.Image;
+
+            navArrowTemp = new ThemeImage(ToolbarIcons.ViewNextImage.Filename, arrowHeight);
+            navArrowTemp.Refresh();
+            NavArrowRight = navArrowTemp.Image;
 
             #endregion
         }
@@ -411,7 +416,10 @@ namespace ImageGlass.UI {
 
             var arrowHeight = (int)(DPIScaling.Transform(Constants.TOOLBAR_ICON_HEIGHT) * NavArrowMultiplier);
 
-            NavArrowLeft = new ThemeImage(ToolbarIcons.ViewPreviousImage.Filename, arrowHeight).Image;
+            var navArrowTemp = new ThemeImage(ToolbarIcons.ViewPreviousImage.Filename, arrowHeight);
+            navArrowTemp.Refresh();
+            NavArrowLeft = navArrowTemp.Image;
+
             NavArrowRight = new ThemeImage(ToolbarIcons.ViewNextImage.Filename, arrowHeight).Image;
 
             #endregion


### PR DESCRIPTION
My "startup tweak" to not load icon images until OnDpiChanged had an unknown side effect. The "calculate navigation region" code for the navigation arrows needed the Left navigation arrow to be actually loaded very early on.

This checkin insures the Left Navigation Arrow is fully initialized at all times, fixing a crash when enabling navigation arrows.
