### PR TITLE
Fix missing toolbar when returning from fullscreen

### DIFF
--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -2838,6 +2838,11 @@ namespace ImageGlass {
 
                 Application.DoEvents();
 
+                // Update toolbar icon according to the new size
+                LoadToolbarIcons(forceReloadIcon: true);
+
+                toolMain.UpdateAlignment();
+                
                 // realign image
                 if (!_isManuallyZoomed) {
                     ApplyZoomMode(Configs.ZoomMode);


### PR DESCRIPTION
The toolbar icons get moved into a "3 points menu" to the far right when exiting fullscreen for me.

To reproduce:

- Opening an image (see all toolbar icons on top and aligned to the middle)
- press F11 to enter Fullscreen
- press F11 again to exit Fullscreen
- all Toolbar icons are gone and moved into an own menu to the far right

Tried the following versions, all have the problem:
ImageGlass_Moon_7.6.11.18_x64
ImageGlass_8.0.12.8_x64
ImageGlass dev self compiled (07.01.2021)

