### PR TITLE
Fix toolbar after maximize

### DIFF
--- a/Source/ImageGlass/frmMain.Designer.cs
+++ b/Source/ImageGlass/frmMain.Designer.cs
@@ -1962,6 +1962,7 @@
             this.Activated += new System.EventHandler(this.frmMain_Activated);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmMain_FormClosing);
             this.Load += new System.EventHandler(this.frmMain_Load);
+            this.Resize += new System.EventHandler(this.frmMain_Resize);
             this.ResizeBegin += new System.EventHandler(this.frmMain_ResizeBegin);
             this.ResizeEnd += new System.EventHandler(this.frmMain_ResizeEnd);
             this.SizeChanged += new System.EventHandler(this.frmMain_SizeChanged);

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -75,6 +75,9 @@ namespace ImageGlass {
         // window size value before resizing
         private Size _windowSize = new(1300, 800);
 
+        // window state value before resizing
+        private FormWindowState _windowState = FormWindowState.Minimized;
+        
         // determine if the image is zoomed
         private bool _isManuallyZoomed;
 
@@ -3393,6 +3396,20 @@ namespace ImageGlass {
         }
 
 
+        private void frmMain_Resize(object sender, EventArgs e) {
+            if (WindowState != _windowState) {
+                _windowState = WindowState;
+                if (WindowState == FormWindowState.Normal) {
+                    // Restored
+
+                    // Update toolbar icon according to the new size
+                    LoadToolbarIcons(forceReloadIcon: true);
+
+                    toolMain.UpdateAlignment();
+                }
+            }
+        }
+        
         private void frmMain_ResizeBegin(object sender, EventArgs e) {
             _windowSize = Size;
         }


### PR DESCRIPTION
This restores the toolbar with icons after:

- Doubleclick on the title bar if window was maximized
- Clicking on the restore Icon if window was maximized