### PR TITLE
Reuse the existing File Explorer window for 'Open Image Location'

### DIFF
--- a/Source/Components/ImageGlass.Library/ImageGlass.Library.csproj
+++ b/Source/Components/ImageGlass.Library/ImageGlass.Library.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Image\ImageInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Comparer\StringLogicalComparer.cs" />
+    <Compile Include="WinAPI\Explorer.cs" />
     <Compile Include="WinAPI\FormBorder.cs" />
     <Compile Include="WinAPI\FormIcon.cs" />
     <Compile Include="WinAPI\MovableForm.cs" />

--- a/Source/Components/ImageGlass.Library/WinAPI/Explorer.cs
+++ b/Source/Components/ImageGlass.Library/WinAPI/Explorer.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using ImageGlass.Base;
+
+namespace ImageGlass.Library.WinAPI {
+    public static class Explorer {
+        [DllImport("shell32.dll", SetLastError = true)]
+        private static extern int SHOpenFolderAndSelectItems(IntPtr pidlFolder, uint cidl, [In, MarshalAs(UnmanagedType.LPArray)] IntPtr[] apidl, uint dwFlags);
+
+        [DllImport("shell32.dll", SetLastError = true)]
+        private static extern void SHParseDisplayName([MarshalAs(UnmanagedType.LPWStr)] string name, IntPtr bindingContext, [Out] out IntPtr pidl, uint sfgaoIn, [Out] out uint psfgaoOut);
+
+        public static void OpenFolderAndSelectItem(string filePath) {
+            uint psfgaoOut;
+
+            var folderPath = Path.GetDirectoryName(filePath);
+
+            SHParseDisplayName(folderPath, IntPtr.Zero, out IntPtr nativeFolder, 0, out psfgaoOut);
+
+            if (nativeFolder == IntPtr.Zero) {
+                App.LogItAsync($"Explorer.OpenFolderAndSelectItem: Cannot find native folder for '{folderPath}'").RunSynchronously();
+                throw new Exception($"Cannot find native folder for '{folderPath}'");
+            }
+
+            SHParseDisplayName(filePath, IntPtr.Zero, out IntPtr nativeFile, 0, out psfgaoOut);
+
+            IntPtr[] fileArray;
+            if (nativeFile == IntPtr.Zero) {
+                // Open the folder without the file selected if we can't find the file
+                fileArray = new IntPtr[0];
+            }
+            else {
+                fileArray = new IntPtr[] { nativeFile };
+            }
+
+            SHOpenFolderAndSelectItems(nativeFolder, (uint)fileArray.Length, fileArray, 0);
+
+            Marshal.FreeCoTaskMem(nativeFolder);
+            if (nativeFile != IntPtr.Zero) {
+                Marshal.FreeCoTaskMem(nativeFile);
+            }
+        }
+    }
+}

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -4819,8 +4819,13 @@ namespace ImageGlass {
 
         private void mnuMainImageLocation_Click(object sender, EventArgs e) {
             if (Local.ImageList.Length > 0) {
-                Process.Start("explorer.exe", "/select,\"" +
-                    Local.ImageList.GetFileName(Local.CurrentIndex) + "\"");
+                try {
+                    Explorer.OpenFolderAndSelectItem(Local.ImageList.GetFileName(Local.CurrentIndex));
+                }
+                catch {
+                    Process.Start("explorer.exe", "/select,\"" +
+                        Local.ImageList.GetFileName(Local.CurrentIndex) + "\"");
+                }
             }
         }
 


### PR DESCRIPTION
'Open Image Location' now attempts to use `SHOpenFolderAndSelectItems` to open file in an existing folder window if possible.

This feature is why I've stuck with Windows Photo Viewer for so long, so I had to try and get it added to ImageGlass.

This is code I found online but I've read over the API documentation and it seems solid.