### PR TITLE
Fixes color management on WebP and AVIF images.

### DIFF
--- a/Source/Components/ImageGlass.Heart/Photo.cs
+++ b/Source/Components/ImageGlass.Heart/Photo.cs
@@ -113,6 +113,11 @@ namespace ImageGlass.Heart {
                 case ".AVIF":
                 case ".PDF":
                     using (var imgColl = new MagickImageCollection(filename, settings)) {
+                        foreach (var imgM in imgColl)
+                        {
+                            (exif, colorProfile) = PreprocesMagickImage((MagickImage)imgM, true); // For extensions other than HEIC, checkRotation is always true
+                        }
+
                         bitmap = imgColl.ToBitmap();
                     }
                     break;


### PR DESCRIPTION
Now the WebP and AVIF images are processed by `MagickImageCollection` and the `bitmap` is directly obtained ([Photo.cs#L112](https://github.com/d2phap/ImageGlass/blob/0db4e37b8c2a1012c331f1d10000158ec94abf5f/Source/Components/ImageGlass.Heart/Photo.cs#L112), I assume it's for animated WebP/AVIF?), which makes the embedded color profile in the image ignored. e.g.
![color_profile_tests](https://user-images.githubusercontent.com/7262364/115423336-4e41d800-a230-11eb-846b-5f0129e290b0.jpg)
The color profile is handled in the `PreprocesMagickImage` function, this pull request calls this function for every `MagickImage` in the `MagickImageCollection`, and generate the correct bitmap after setting the color profile for it. 
P.S. As the `PreprocesMagickImage` function handles only thumbnail, exif and color profile, I think it's ok to directly call it and unnecessary to split color profile handling to another function.
The images files used for testing is here: [Upper_Left.jpg](https://datasone.moe:5450/Downloads/Upper_Left.jpg) [Upper_Left.webp](https://datasone.moe:5450/Downloads/Upper_Left.webp) [Upper_Left.avif](https://datasone.moe:5450/Downloads/Upper_Left.avif)