### PR TITLE
Fix issues #1075, #1055

### DIFF
--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -4313,7 +4313,11 @@ namespace ImageGlass {
                 FileName = Path.GetFileNameWithoutExtension(currentFile),
                 RestoreDirectory = true,
             };
-            saveDialog.CustomPlaces.Add(Path.GetDirectoryName(currentFile));
+
+            // When saving image from clipboard, there is no path (issue #1075)
+            // In the window of time while IG is populating the image list, there is no path (issue #1055)
+            var path2 = string.IsNullOrEmpty(currentFile) ? currentFile : Path.GetDirectoryName(currentFile);
+            saveDialog.CustomPlaces.Add(path2);
 
 
             // Use the last-selected file extension, if available.


### PR DESCRIPTION
IG has no path for SaveAs in certain situations. I shoulda seen this when I fixed the substring() issue...

Note: fixes only the "Save As" portion of Allan's bug (#1055). Other instances where IG assumes the list to be fully populated still need to be examined (in my opinion ...)