### PR TITLE
Refactor: ImageGlass.Heart.Photo.Load()

### DIFF
--- a/Source/.vs/ImageGlass/project-colors.json
+++ b/Source/.vs/ImageGlass/project-colors.json
@@ -1,0 +1,46 @@
+{
+  "Version": 1,
+  "ProjectMap": {
+    "51493b09-7a0e-461f-be18-a6cf629a8fab": {
+      "ProjectGuid": "51493b09-7a0e-461f-be18-a6cf629a8fab",
+      "DisplayName": "ImageGlass.Heart",
+      "ColorIndex": 0
+    },
+    "97f81263-4825-4c06-a7b6-2e999765fa28": {
+      "ProjectGuid": "97f81263-4825-4c06-a7b6-2e999765fa28",
+      "DisplayName": "ImageGlass",
+      "ColorIndex": 1
+    },
+    "a2fe74e1-b743-11d0-ae1a-00a0c90fffc3": {
+      "ProjectGuid": "a2fe74e1-b743-11d0-ae1a-00a0c90fffc3",
+      "DisplayName": "Miscellaneous Files",
+      "ColorIndex": -1
+    },
+    "4bb719ed-b68b-4cb1-aaaf-ba0e3bc5fe81": {
+      "ProjectGuid": "4bb719ed-b68b-4cb1-aaaf-ba0e3bc5fe81",
+      "DisplayName": "ImageGlass.Library",
+      "ColorIndex": 2
+    },
+    "4bad780f-8071-4034-9020-ecc9f4352422": {
+      "ProjectGuid": "4bad780f-8071-4034-9020-ecc9f4352422",
+      "DisplayName": "ImageGlass.Settings",
+      "ColorIndex": 3
+    },
+    "76486f88-aa16-4d7d-bbf6-0f1c604d5853": {
+      "ProjectGuid": "76486f88-aa16-4d7d-bbf6-0f1c604d5853",
+      "DisplayName": "ImageGlass.UI",
+      "ColorIndex": 4
+    },
+    "4159c8d3-c18d-4bed-8be6-9bad1b0ca4f6": {
+      "ProjectGuid": "4159c8d3-c18d-4bed-8be6-9bad1b0ca4f6",
+      "DisplayName": "ImageGlass.ImageBox",
+      "ColorIndex": 5
+    },
+    "6cc96a70-6773-41b5-9fca-4f0ab6fad8ca": {
+      "ProjectGuid": "6cc96a70-6773-41b5-9fca-4f0ab6fad8ca",
+      "DisplayName": "ImageGlass.Base",
+      "ColorIndex": 6
+    }
+  },
+  "NextColorIndex": 7
+}

--- a/Source/Components/ImageGlass.Heart/Factory.cs
+++ b/Source/Components/ImageGlass.Heart/Factory.cs
@@ -27,6 +27,7 @@ using System.Threading.Tasks;
 
 namespace ImageGlass.Heart {
     public sealed class Factory: IDisposable {
+
         #region PRIVATE PROPERTIES
 
         /// <summary>
@@ -88,6 +89,11 @@ namespace ImageGlass.Heart {
                 return list;
             }
         }
+
+        /// <summary>
+        /// Gets, sets the list of formats that only load the first page forcefully
+        /// </summary>
+        public HashSet<string> SinglePageFormats { get; set; } = new();
 
         /// <summary>
         /// Gets, sets the number of maximum items in queue list for 1 direction (Next or Back navigation).
@@ -214,7 +220,8 @@ namespace ImageGlass.Heart {
                             isApplyColorProfileForAll: IsApplyColorProfileForAll,
                             channel: Channels,
                             useEmbeddedThumbnail: UseEmbeddedThumbnail,
-                            useRawThumbnail: UseRawThumbnail
+                            useRawThumbnail: UseRawThumbnail,
+                            forceLoadFirstPage: SinglePageFormats.Contains(img.Extension)
                         ).ConfigureAwait(true);
                     }
                 }
@@ -258,7 +265,8 @@ namespace ImageGlass.Heart {
                     isApplyColorProfileForAll: IsApplyColorProfileForAll,
                     channel: Channels,
                     useEmbeddedThumbnail: UseEmbeddedThumbnail,
-                    useRawThumbnail: UseRawThumbnail
+                    useRawThumbnail: UseRawThumbnail,
+                    forceLoadFirstPage: SinglePageFormats.Contains(ImgList[index].Extension)
                 ).ConfigureAwait(true);
             }
             // get image data from cache
@@ -317,6 +325,17 @@ namespace ImageGlass.Heart {
             if (ImgList[index] != null) {
                 ImgList[index].Filename = filename;
             }
+        }
+
+        /// <summary>
+        /// Gets file extension. Ex: .jpg
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public string GetFileExtension(int index) {
+            var filename = GetFileName(index);
+
+            return Path.GetExtension(filename);
         }
 
         /// <summary>

--- a/Source/Components/ImageGlass.Heart/Img.cs
+++ b/Source/Components/ImageGlass.Heart/Img.cs
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 using System;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.IO;
 using System.Threading.Tasks;
 using ImageMagick;
 
@@ -42,6 +43,11 @@ namespace ImageGlass.Heart {
         /// Gets, sets filename of Img
         /// </summary>
         public string Filename { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets file extension. Ex: .jpg
+        /// </summary>
+        public string Extension => Path.GetExtension(this.Filename);
 
         /// <summary>
         /// Gets, sets Bitmap data
@@ -109,7 +115,8 @@ namespace ImageGlass.Heart {
             bool isApplyColorProfileForAll = false,
             int channel = -1,
             bool useEmbeddedThumbnail = false,
-            bool useRawThumbnail = true) {
+            bool useRawThumbnail = true,
+            bool forceLoadFirstPage = false) {
             // reset done status
             IsDone = false;
 
@@ -125,7 +132,8 @@ namespace ImageGlass.Heart {
                     isApplyColorProfileForAll: isApplyColorProfileForAll,
                     channel: channel,
                     useEmbeddedThumbnail: useEmbeddedThumbnail,
-                    useRawThumbnail: useRawThumbnail
+                    useRawThumbnail: useRawThumbnail,
+                    forceLoadFirstPage: forceLoadFirstPage
                 ).ConfigureAwait(true);
 
                 Image = data.Image;

--- a/Source/Components/ImageGlass.Heart/Photo.cs
+++ b/Source/Components/ImageGlass.Heart/Photo.cs
@@ -226,6 +226,9 @@ namespace ImageGlass.Heart {
                         imgM.Read(filename, settings);
                     }
                 }
+                else {
+                    imgM.Read(filename, settings);
+                }
 
 
                 // Issue #679: fix targa display with Magick.NET 7.15.x 
@@ -280,7 +283,17 @@ namespace ImageGlass.Heart {
         /// <param name="useRawThumbnail">Use embeded thumbnail if found</param>
         /// <param name="forceLoadFirstPage">Only load first page of the image</param>
         /// <returns></returns>
-        public static async Task<ImgData> LoadAsync(string filename, Size size = new Size(), string colorProfileName = "sRGB", bool isApplyColorProfileForAll = false, int quality = 100, int channel = -1, bool useEmbeddedThumbnail = false, bool useRawThumbnail = true, bool forceLoadFirstPage = false) {
+        public static async Task<ImgData> LoadAsync(
+            string filename,
+            Size size = new Size(),
+            string colorProfileName = "sRGB",
+            bool isApplyColorProfileForAll = false,
+            int quality = 100,
+            int channel = -1,
+            bool useEmbeddedThumbnail = false,
+            bool useRawThumbnail = true,
+            bool forceLoadFirstPage = false
+        ) {
             var data = await Task.Run(() => {
                 return Load(
                     filename,
@@ -308,7 +321,7 @@ namespace ImageGlass.Heart {
         public static Bitmap GetThumbnail(string filename, Size size, bool useEmbeddedThumbnail = true) {
             var data = Load(filename,
                     size: size,
-                    quality: 75,
+                    quality: 70,
                     useEmbeddedThumbnail: useEmbeddedThumbnail,
                     forceLoadFirstPage: true);
 
@@ -326,7 +339,7 @@ namespace ImageGlass.Heart {
             var data = await Task.Run(() => {
                 return Load(filename,
                     size: size,
-                    quality: 75,
+                    quality: 70,
                     useEmbeddedThumbnail: useEmbeddedThumbnail,
                     forceLoadFirstPage: true);
             }).ConfigureAwait(true);

--- a/Source/Components/ImageGlass.Heart/Photo.cs
+++ b/Source/Components/ImageGlass.Heart/Photo.cs
@@ -43,6 +43,7 @@ namespace ImageGlass.Heart {
         /// <param name="channel">MagickImage.Channel value</param>
         /// <param name="useEmbeddedThumbnail">Return the embedded thumbnail if required size was not found.</param>
         /// <param name="useRawThumbnail">Return the RAW embedded thumbnail if found.</param>
+        /// <param name="forceLoadFirstPage">Only load first page of the image</param>
         /// <returns>Bitmap</returns>
         public static ImgData Load(
             string filename,
@@ -52,7 +53,8 @@ namespace ImageGlass.Heart {
             int quality = 100,
             int channel = -1,
             bool useEmbeddedThumbnail = false,
-            bool useRawThumbnail = true
+            bool useRawThumbnail = true,
+            bool forceLoadFirstPage = false
         ) {
             Bitmap bitmap = null;
             IExifProfile exif = null;
@@ -100,9 +102,8 @@ namespace ImageGlass.Heart {
                     bitmap = ConvertBase64ToBitmap(base64Content);
                     break;
 
+
                 case ".GIF":
-                case ".TIF":
-                case ".TIFF":
                 case ".FAX":
                     // Note: Using FileStream is much faster than using MagickImageCollection
 
@@ -115,19 +116,6 @@ namespace ImageGlass.Heart {
                     }
                     break;
 
-                case ".ICO":
-                case ".WEBP":
-                case ".AVIF":
-                case ".PDF":
-                    using (var imgColl = new MagickImageCollection(filename, settings)) {
-                        foreach (var imgM in imgColl) {
-                            // For extensions other than HEIC, checkRotation is always true
-                            (exif, colorProfile) = PreprocesMagickImage((MagickImage)imgM, true);
-                        }
-
-                        bitmap = imgColl.ToBitmap();
-                    }
-                    break;
 
                 default:
                     ReadWithMagickImage();
@@ -157,7 +145,7 @@ namespace ImageGlass.Heart {
                 // Use embedded thumbnails if specified
                 if (profile != null && useEmbeddedThumbnail) {
                     // Fetch the embedded thumbnail
-                    var thumbM = profile.CreateThumbnail();
+                    using var thumbM = profile.CreateThumbnail();
                     if (thumbM != null) {
                         bitmap = thumbM.ToBitmap();
                     }
@@ -198,61 +186,44 @@ namespace ImageGlass.Heart {
             }
 
 
-            // Separate color channel
-            MagickImage ApplyColorChannel(MagickImage imgM) {
-                if (channel != -1) {
-                    var magickChannel = (Channels)channel;
-                    var channelImgM = (MagickImage)imgM.Separate(magickChannel).First();
-
-                    if (imgM.HasAlpha && magickChannel != Channels.Alpha) {
-                        using var alpha = imgM.Separate(Channels.Alpha).First();
-                        channelImgM.Composite(alpha, CompositeOperator.CopyAlpha);
-                    }
-
-                    return channelImgM;
-                }
-
-                return imgM;
-            }
-
 
             void ReadWithMagickImage() {
-                MagickImage imgM;
+                var checkRotation = ext != ".HEIC";
+                using var imgColl = new MagickImageCollection();
 
                 // Issue #530: ImageMagick falls over if the file path is longer than the (old) windows limit of 260 characters. Workaround is to read the file bytes, but that requires using the "long path name" prefix to succeed.
                 if (filename.Length > 260) {
                     var newFilename = Helpers.PrefixLongPath(filename);
                     var allBytes = File.ReadAllBytes(newFilename);
 
-                    imgM = new MagickImage(allBytes, settings);
-                }
-                else if (useRawThumbnail is false) {
-                    imgM = new MagickImage(filename, settings);
+                    imgColl.Ping(allBytes, settings);
                 }
                 else {
-                    var tempM = new MagickImage();
+                    imgColl.Ping(filename, settings);
+                }
 
-                    // Fixed #708: length and filesize do not match
-                    tempM.Settings.SetDefines(new BmpReadDefines {
-                        IgnoreFileSize = true,
-                    });
 
-                    // Fix RAW color
-                    tempM.Settings.SetDefines(new DngReadDefines() {
-                        UseCameraWhitebalance = true,
-                        OutputColor = DngOutputColor.AdobeRGB,
-                        ReadThumbnail = true,
-                    });
+                if (imgColl.Count > 1 && forceLoadFirstPage is false) {
+                    imgColl.Read(filename, settings);
+                    foreach (var imgPageM in imgColl) {
+                        (exif, colorProfile) = PreprocesMagickImage((MagickImage)imgPageM, checkRotation);
+                    }
 
-                    tempM.Ping(filename);
-                    var profile = tempM.GetProfile("dng:thumbnail");
+                    bitmap = imgColl.ToBitmap();
+                    return;
+                }
+
+
+                using var imgM = new MagickImage();
+                if (useRawThumbnail is true) {
+                    var profile = imgColl[0].GetProfile("dng:thumbnail");
 
                     try {
                         // try to get thumbnail
-                        imgM = new MagickImage(profile?.GetData());
+                        imgM.Read(profile?.GetData(), settings);
                     }
                     catch {
-                        imgM = new MagickImage(filename, settings);
+                        imgM.Read(filename, settings);
                     }
                 }
 
@@ -263,14 +234,11 @@ namespace ImageGlass.Heart {
                 }
 
 
-                var checkRotation = ext != ".HEIC";
+                imgM.Quality = quality;
                 (exif, colorProfile) = PreprocesMagickImage(imgM, checkRotation);
 
-                using (var channelImgM = ApplyColorChannel(imgM)) {
-                    bitmap = channelImgM.ToBitmap();
-                }
-
-                imgM.Dispose();
+                using var channelImgM = ApplyColorChannel(imgM, channel);
+                bitmap = channelImgM.ToBitmap();
             }
             #endregion
 
@@ -281,6 +249,23 @@ namespace ImageGlass.Heart {
                 ColorProfile = colorProfile,
             };
         }
+
+        private static MagickImage ApplyColorChannel(MagickImage imgM, int channel) {
+            if (channel != -1) {
+                var magickChannel = (Channels)channel;
+                using var channelImgM = (MagickImage)imgM.Separate(magickChannel).First();
+
+                if (imgM.HasAlpha && magickChannel != Channels.Alpha) {
+                    using var alpha = imgM.Separate(Channels.Alpha).First();
+                    channelImgM.Composite(alpha, CompositeOperator.CopyAlpha);
+                }
+
+                return channelImgM;
+            }
+
+            return imgM;
+        }
+
 
         /// <summary>
         /// Load image from file
@@ -293,8 +278,9 @@ namespace ImageGlass.Heart {
         /// <param name="channel">MagickImage.Channel value</param>
         /// <param name="useEmbeddedThumbnail">Use embeded thumbnail if found</param>
         /// <param name="useRawThumbnail">Use embeded thumbnail if found</param>
+        /// <param name="forceLoadFirstPage">Only load first page of the image</param>
         /// <returns></returns>
-        public static async Task<ImgData> LoadAsync(string filename, Size size = new Size(), string colorProfileName = "sRGB", bool isApplyColorProfileForAll = false, int quality = 100, int channel = -1, bool useEmbeddedThumbnail = false, bool useRawThumbnail = true) {
+        public static async Task<ImgData> LoadAsync(string filename, Size size = new Size(), string colorProfileName = "sRGB", bool isApplyColorProfileForAll = false, int quality = 100, int channel = -1, bool useEmbeddedThumbnail = false, bool useRawThumbnail = true, bool forceLoadFirstPage = false) {
             var data = await Task.Run(() => {
                 return Load(
                     filename,
@@ -304,7 +290,8 @@ namespace ImageGlass.Heart {
                     quality,
                     channel,
                     useEmbeddedThumbnail,
-                    useRawThumbnail
+                    useRawThumbnail,
+                    forceLoadFirstPage
                 );
             }).ConfigureAwait(true);
 
@@ -322,7 +309,8 @@ namespace ImageGlass.Heart {
             var data = Load(filename,
                     size: size,
                     quality: 75,
-                    useEmbeddedThumbnail: useEmbeddedThumbnail);
+                    useEmbeddedThumbnail: useEmbeddedThumbnail,
+                    forceLoadFirstPage: true);
 
             return data.Image;
         }
@@ -339,7 +327,8 @@ namespace ImageGlass.Heart {
                 return Load(filename,
                     size: size,
                     quality: 75,
-                    useEmbeddedThumbnail: useEmbeddedThumbnail);
+                    useEmbeddedThumbnail: useEmbeddedThumbnail,
+                    forceLoadFirstPage: true);
             }).ConfigureAwait(true);
 
             return data.Image;

--- a/Source/Components/ImageGlass.Settings/Configs.cs
+++ b/Source/Components/ImageGlass.Settings/Configs.cs
@@ -21,7 +21,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using ImageGlass.Base;

--- a/Source/Components/ImageGlass.Settings/Configs.cs
+++ b/Source/Components/ImageGlass.Settings/Configs.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using ImageGlass.Base;
@@ -385,6 +386,11 @@ namespace ImageGlass.Settings {
         public static HashSet<string> AllFormats { get; set; } = new();
 
         /// <summary>
+        /// Gets, sets the list of formats that only load the first page forcefully
+        /// </summary>
+        public static HashSet<string> SinglePageFormats { get; set; } = new() { "*.psd;" };
+
+        /// <summary>
         /// Gets, sets the list of keycombo actions
         /// </summary>
         public static Dictionary<KeyCombos, AssignableActions> KeyComboActions = Constants.DefaultKeycomboActions;
@@ -393,6 +399,7 @@ namespace ImageGlass.Settings {
         /// Gets, sets the list of toolbar buttons
         /// </summary>
         public static List<ToolbarButton> ToolbarButtons { get; set; } = Constants.DefaultToolbarButtons;
+
 
         #endregion
 
@@ -699,6 +706,9 @@ namespace ImageGlass.Settings {
             var formats = Get<string>(nameof(AllFormats), Constants.IMAGE_FORMATS);
             AllFormats = GetImageFormats(formats);
 
+            formats = Get<string>(nameof(SinglePageFormats), string.Join(";", SinglePageFormats));
+            SinglePageFormats = GetImageFormats(formats);
+
             #endregion
 
             #region KeyComboActions
@@ -889,6 +899,7 @@ namespace ImageGlass.Settings {
             Set(nameof(ZoomLevels), Helpers.IntArrayToString(ZoomLevels));
             Set(nameof(EditApps), GetEditApps(EditApps));
             Set(nameof(AllFormats), GetImageFormats(AllFormats));
+            Set(nameof(SinglePageFormats), GetImageFormats(SinglePageFormats));
             Set(nameof(KeyComboActions), GetKeyComboActions(KeyComboActions));
             Set(nameof(ToolbarButtons), GetToolbarButtons(ToolbarButtons));
 

--- a/Source/Components/ImageGlass.UI/Theme/ThemeImage.cs
+++ b/Source/Components/ImageGlass.UI/Theme/ThemeImage.cs
@@ -67,7 +67,10 @@ namespace ImageGlass.UI {
             }
 
             try {
-                Image = Photo.Load(Filename, new Size(Height, Height)).Image;
+                Image = Photo.Load(Filename,
+                    size: new(Height, Height),
+                    forceLoadFirstPage: true)
+                    .Image;
             }
             catch { }
         }

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -706,6 +706,7 @@ namespace ImageGlass {
                 Local.ImageList.IsApplyColorProfileForAll = Configs.IsApplyColorProfileForAll;
                 Local.ImageList.ColorProfileName = Configs.ColorProfile;
                 Local.ImageList.UseRawThumbnail = Configs.IsUseRawThumbnail;
+                Local.ImageList.SinglePageFormats = Configs.SinglePageFormats;
 
                 // put app in a 'busy' state around image load: allows us to prevent the user
                 // from skipping past a slow-to-load image by processing too many arrow clicks
@@ -724,7 +725,9 @@ namespace ImageGlass {
                             colorProfileName: Configs.ColorProfile,
                             isApplyColorProfileForAll: Configs.IsApplyColorProfileForAll,
                             channel: (int)Local.Channels,
-                            useRawThumbnail: Local.ImageList.UseRawThumbnail);
+                            useRawThumbnail: Local.ImageList.UseRawThumbnail,
+                            forceLoadFirstPage: Configs.SinglePageFormats.Contains(bmpImg.Extension)
+                            );
                     }
                     else {
                         bmpImg = await Local.ImageList.GetImgAsync(

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -29,7 +29,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using FileWatcherEx;


### PR DESCRIPTION
- Refactor `Photo.Load()` in ImageGlass.Heart
  + Auto-detects multipage formats, process all image pages in multipage formats by default, fixes #906
  + Add snew parameter: `forceLoadFirstPage = false` to force handle multipage format as single-page format
- Adds new setting `Configs.SinglePageFormats = ["*.psd"]` to define the formats to read as single-page