### PR TITLE
When enabling Window fit mode, window should be fit without resetting zoom, when disabling, nothing should be done.

### DIFF
--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -5025,11 +5025,7 @@ namespace ImageGlass {
             }
 
             if (Configs.IsWindowFit) {
-                WindowFitMode();
-            }
-            else {
-                MinimumSize = new(0, 0);
-                ApplyZoomMode(Configs.ZoomMode);
+                WindowFitMode(false);
             }
         }
 


### PR DESCRIPTION
I think current way that `Window fit` mode trigger works makes too much hassle, it should be dead simple:
a) it should fit window when enabling,
b) it should do not change window zoom or size when disabling.