### PR TITLE
Allow the slideshow interval to be less than 1 second

### DIFF
--- a/Source/Components/ImageGlass.Settings/Configs.cs
+++ b/Source/Components/ImageGlass.Settings/Configs.cs
@@ -1041,7 +1041,7 @@ namespace ImageGlass.Settings {
             var intervalTo = IsRandomSlideshowInterval ? SlideShowIntervalTo : SlideShowInterval;
 
             var ran = new Random();
-            var interval = (float)(ran.NextDouble() * (SlideShowIntervalTo - SlideShowInterval) + SlideShowInterval);
+            var interval = (float)(ran.NextDouble() * (intervalTo - SlideShowInterval) + SlideShowInterval);
 
             return interval;
         }

--- a/Source/Components/ImageGlass.Settings/Configs.cs
+++ b/Source/Components/ImageGlass.Settings/Configs.cs
@@ -333,12 +333,12 @@ namespace ImageGlass.Settings {
         /// <summary>
         /// Gets, sets slide show interval (minimum value if it's random)
         /// </summary>
-        public static uint SlideShowInterval { get; set; } = 5;
+        public static float SlideShowInterval { get; set; } = 5;
 
         /// <summary>
         /// Gets, sets the maximum slide show interval value
         /// </summary>
-        public static uint SlideShowIntervalTo { get; set; } = 5;
+        public static float SlideShowIntervalTo { get; set; } = 5;
 
         /// <summary>
         /// Gets, sets the number of Images after which alert is played
@@ -1037,11 +1037,11 @@ namespace ImageGlass.Settings {
         /// Randomize slideshow interval in seconds
         /// </summary>
         /// <returns></returns>
-        public static uint RandomizeSlideshowInterval() {
-            var intervalTo = (int)(IsRandomSlideshowInterval ? SlideShowIntervalTo : SlideShowInterval);
+        public static float RandomizeSlideshowInterval() {
+            var intervalTo = IsRandomSlideshowInterval ? SlideShowIntervalTo : SlideShowInterval;
 
             var ran = new Random();
-            var interval = (uint)ran.Next((int)SlideShowInterval, intervalTo);
+            var interval = (float)(ran.NextDouble() * (SlideShowIntervalTo - SlideShowInterval) + SlideShowInterval);
 
             return interval;
         }

--- a/Source/ImageGlass/frmMain.Designer.cs
+++ b/Source/ImageGlass/frmMain.Designer.cs
@@ -210,7 +210,7 @@
             // 
             // timSlideShow
             // 
-            this.timSlideShow.Interval = 1000;
+            this.timSlideShow.Interval = 1;
             this.timSlideShow.Tick += new System.EventHandler(this.timSlideShow_Tick);
             // 
             // mnuMain

--- a/Source/ImageGlass/frmSetting.Designer.cs
+++ b/Source/ImageGlass/frmSetting.Designer.cs
@@ -1135,6 +1135,12 @@ namespace ImageGlass
             // numSlideShowInterval
             // 
             this.numSlideShowInterval.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
+            this.numSlideShowInterval.Increment = new decimal(new int[] {
+            25,
+            0,
+            0,
+            131072});
+            this.numSlideShowInterval.DecimalPlaces = 3;
             this.numSlideShowInterval.Location = new System.Drawing.Point(4, 4);
             this.numSlideShowInterval.Margin = new System.Windows.Forms.Padding(4);
             this.numSlideShowInterval.Maximum = new decimal(new int[] {
@@ -1143,7 +1149,7 @@ namespace ImageGlass
             0,
             0});
             this.numSlideShowInterval.Minimum = new decimal(new int[] {
-            1,
+            0,
             0,
             0,
             0});
@@ -1171,6 +1177,12 @@ namespace ImageGlass
             // numSlideshowIntervalTo
             // 
             this.numSlideshowIntervalTo.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
+            this.numSlideshowIntervalTo.Increment = new decimal(new int[] {
+            25,
+            0,
+            0,
+            131072});
+            this.numSlideshowIntervalTo.DecimalPlaces = 3;
             this.numSlideshowIntervalTo.Location = new System.Drawing.Point(157, 4);
             this.numSlideshowIntervalTo.Margin = new System.Windows.Forms.Padding(4);
             this.numSlideshowIntervalTo.Maximum = new decimal(new int[] {

--- a/Source/ImageGlass/frmSetting.Designer.cs
+++ b/Source/ImageGlass/frmSetting.Designer.cs
@@ -1136,10 +1136,10 @@ namespace ImageGlass
             // 
             this.numSlideShowInterval.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
             this.numSlideShowInterval.Increment = new decimal(new int[] {
-            25,
+            1,
             0,
             0,
-            131072});
+            0});
             this.numSlideShowInterval.DecimalPlaces = 3;
             this.numSlideShowInterval.Location = new System.Drawing.Point(4, 4);
             this.numSlideShowInterval.Margin = new System.Windows.Forms.Padding(4);
@@ -1178,10 +1178,10 @@ namespace ImageGlass
             // 
             this.numSlideshowIntervalTo.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
             this.numSlideshowIntervalTo.Increment = new decimal(new int[] {
-            25,
+            1,
             0,
             0,
-            131072});
+            0});
             this.numSlideshowIntervalTo.DecimalPlaces = 3;
             this.numSlideshowIntervalTo.Location = new System.Drawing.Point(157, 4);
             this.numSlideshowIntervalTo.Margin = new System.Windows.Forms.Padding(4);

--- a/Source/ImageGlass/frmSetting.cs
+++ b/Source/ImageGlass/frmSetting.cs
@@ -717,8 +717,8 @@ namespace ImageGlass {
             chkRandomSlideshowInterval.Checked = Configs.IsRandomSlideshowInterval;
 
             // Set value of slideshow intervals
-            numSlideShowInterval.Value = Configs.SlideShowInterval;
-            numSlideshowIntervalTo.Value = Configs.SlideShowIntervalTo;
+            numSlideShowInterval.Value = (decimal)Configs.SlideShowInterval;
+            numSlideshowIntervalTo.Value = (decimal)Configs.SlideShowIntervalTo;
             numSlideShowInterval_ValueChanged(null, null); // format interval value
 
             // Full screen configs 
@@ -736,10 +736,10 @@ namespace ImageGlass {
             numSlideshowIntervalTo.Minimum = numSlideShowInterval.Value;
 
             // format value
-            var time = TimeSpan.FromSeconds((double)numSlideShowInterval.Value).ToString("mm':'ss");
+            var time = TimeSpan.FromSeconds((double)numSlideShowInterval.Value).ToString("mm':'ss'.'fff");
 
             if (chkRandomSlideshowInterval.Checked) {
-                var timeTo = TimeSpan.FromSeconds((double)numSlideshowIntervalTo.Value).ToString("mm':'ss");
+                var timeTo = TimeSpan.FromSeconds((double)numSlideshowIntervalTo.Value).ToString("mm':'ss'.'fff");
 
                 time = $"{time} - {timeTo}";
             }
@@ -749,9 +749,9 @@ namespace ImageGlass {
 
         private void numSlideshowIntervalTo_ValueChanged(object sender, EventArgs e) {
             // format value
-            var time = TimeSpan.FromSeconds((double)numSlideShowInterval.Value).ToString("mm':'ss");
+            var time = TimeSpan.FromSeconds((double)numSlideShowInterval.Value).ToString("mm':'ss'.'fff");
 
-            var timeTo = TimeSpan.FromSeconds((double)numSlideshowIntervalTo.Value).ToString("mm':'ss");
+            var timeTo = TimeSpan.FromSeconds((double)numSlideshowIntervalTo.Value).ToString("mm':'ss'.'fff");
 
             time = $"{time} - {timeTo}";
 
@@ -2105,8 +2105,8 @@ namespace ImageGlass {
             Configs.IsShowSlideshowCountdown = chkShowSlideshowCountdown.Checked;
             Configs.IsRandomSlideshowInterval = chkRandomSlideshowInterval.Checked;
 
-            Configs.SlideShowInterval = (uint)numSlideShowInterval.Value;
-            Configs.SlideShowIntervalTo = (uint)numSlideshowIntervalTo.Value;
+            Configs.SlideShowInterval = (float)numSlideShowInterval.Value;
+            Configs.SlideShowIntervalTo = (float)numSlideshowIntervalTo.Value;
 
             // Full screen
             Configs.IsHideToolbarInFullscreen = chkHideToolbarInFullScreen.Checked;


### PR DESCRIPTION
This PR allows users to set the slide show's interval with milliseconds precision thus allowing them to set an interval lower than 1s. It covers this feature request : https://github.com/d2phap/ImageGlass/issues/1155

![untitled](https://user-images.githubusercontent.com/5278648/179421772-f2a60e03-3ee0-4ca0-95e8-e1144743535f.png)

This uses a Stopwatch for the precision but the check is still done by the `timSlideShow_Tick` method with the `timSlideShow.Interval` now set to 1ms. 1ms will probably be too fast for Windows hence the Stopwatch. Setting the interval of `timSlideShow` this low guarantees enough precision for a slide show. This is as precise as the current version. 

I decided to not append milliseconds to the label on the screen, I found it to be too much clutter for the eye. If you decide to append it, the string's format should be `mm':'ss'.'fff`. (L2332, frmMain.cs)

Ben