### PR TITLE
exit application from context menu

### DIFF
--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -4271,6 +4271,16 @@ namespace ImageGlass {
         }
         #endregion
 
+        #region Menu Common
+        private void SetShortcutExit() {
+            if (Configs.IsContinueRunningBackground) {
+                mnuMainExitApplication.ShortcutKeyDisplayString = "Shift+ESC";
+            }
+            else {
+                mnuMainExitApplication.ShortcutKeyDisplayString = Configs.IsPressESCToQuit ? "ESC" : "Alt+F4";
+            }
+        }
+        #endregion
 
         #region Context Menu
         private void OpenShortcutMenu(ToolStripMenuItem parentMenu) {
@@ -4378,6 +4388,10 @@ namespace ImageGlass {
                 mnuContext.Items.Add(UI.Menu.Clone(mnuMainImageLocation));
                 mnuContext.Items.Add(UI.Menu.Clone(mnuMainImageProperties));
             }
+
+            SetShortcutExit();
+            mnuContext.Items.Add(new ToolStripSeparator());
+            mnuContext.Items.Add(UI.Menu.Clone(mnuMainExitApplication));
         }
 
         private void MnuTray_Opening(object sender, CancelEventArgs e) {
@@ -5680,12 +5694,7 @@ namespace ImageGlass {
                 }
 
                 // add hotkey to Exit menu
-                if (Configs.IsContinueRunningBackground) {
-                    mnuMainExitApplication.ShortcutKeyDisplayString = "Shift+ESC";
-                }
-                else {
-                    mnuMainExitApplication.ShortcutKeyDisplayString = Configs.IsPressESCToQuit ? "ESC" : "Alt+F4";
-                }
+                SetShortcutExit();
 
                 // Get EditApp for editing
                 UpdateEditAppInfoForMenu();


### PR DESCRIPTION
#1322 #1390

![image](https://user-images.githubusercontent.com/5278648/180395112-dfbd6c9a-6773-4f5a-9679-bb8a7f906eca.png)
![image](https://user-images.githubusercontent.com/5278648/180395157-f536e777-f660-43d7-9bb0-192920b66ffd.png)

I had to pull the logic that add the keyboard shortcut to the entry label in its own method to make it DRY. Without this, the "ESC"/"Alt+F4" would not show up in the context menu until the user opened the main menu.