### PR TITLE
#1498: implemented issue 1498 - added the option to hide the set as desktopbackground

### DIFF
--- a/Source/Components/ImageGlass.Library/Language/Language.cs
+++ b/Source/Components/ImageGlass.Library/Language/Language.cs
@@ -468,6 +468,7 @@ namespace ImageGlass.Library {
             Items.Add("frmSetting.lblImageBoosterCachedCount", "Number of images cached by ImageBooster (one direction)"); //v7.0
             Items.Add("frmSetting.chkIsPlayImageChangeSound", "Play sound when image changes"); //v8.4
             Items.Add("frmSetting.lblNumberImagesNotify", "Number of images to notify"); //v8.4
+            Items.Add("frmSetting.chkShowSetDesktopInContext", "Show option to set image as desktop background in context menu"); //v8.4
             #endregion
 
             #region Color Management

--- a/Source/Components/ImageGlass.Settings/Configs.cs
+++ b/Source/Components/ImageGlass.Settings/Configs.cs
@@ -70,6 +70,11 @@ namespace ImageGlass.Settings {
         public static bool IsPlayImageChangeSound { get; set; } = false;
 
         /// <summary>
+        /// Gets, sets value of show set as desktop background in context menu
+        /// </summary>
+        public static bool ShowSetDesktopInContext { get; set; } = true;
+
+        /// <summary>
         /// Gets, sets value indicating whether the window is full screen or not
         /// </summary>
         public static bool IsFullScreen { get; set; } = false;
@@ -618,6 +623,7 @@ namespace ImageGlass.Settings {
             IsShowSlideshowCountdown = Get<bool>(nameof(IsShowSlideshowCountdown), IsShowSlideshowCountdown);
             IsRandomSlideshowInterval = Get<bool>(nameof(IsRandomSlideshowInterval), IsRandomSlideshowInterval);
             IsPlayImageChangeSound = Get<bool>(nameof(IsPlayImageChangeSound), IsPlayImageChangeSound);
+            ShowSetDesktopInContext = Get<bool>(nameof(ShowSetDesktopInContext), ShowSetDesktopInContext);
             IsFullScreen = Get<bool>(nameof(IsFullScreen), IsFullScreen);
             IsShowThumbnail = Get<bool>(nameof(IsShowThumbnail), IsShowThumbnail);
             IsCenterImage = Get<bool>(nameof(IsCenterImage), IsCenterImage);
@@ -867,6 +873,7 @@ namespace ImageGlass.Settings {
             Set(nameof(IsShowSlideshowCountdown), IsShowSlideshowCountdown);
             Set(nameof(IsRandomSlideshowInterval), IsRandomSlideshowInterval);
             Set(nameof(IsPlayImageChangeSound), IsPlayImageChangeSound);
+            Set(nameof(ShowSetDesktopInContext), ShowSetDesktopInContext);
             Set(nameof(IsFullScreen), IsFullScreen);
             Set(nameof(IsShowThumbnail), IsShowThumbnail);
             Set(nameof(IsCenterImage), IsCenterImage);

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -118,6 +118,9 @@ namespace ImageGlass {
 
         private bool _shouldPlayImgChangeAlert = Configs.IsPlayImageChangeSound;
 
+        // show set as desktop background in context menu
+        private bool _shouldShowSetAsDesktopBackgroundInContext = Configs.ShowSetDesktopInContext;
+
         private readonly ToolFormManager _toolManager = new();
 
         private MovableForm _movableForm;
@@ -4366,7 +4369,7 @@ namespace ImageGlass {
                 #endregion
             }
 
-            if (!imageNotFound && !imageError || Local.IsTempMemoryData) {
+            if (Configs.ShowSetDesktopInContext && (!imageNotFound && !imageError || Local.IsTempMemoryData)) {
                 mnuContext.Items.Add(UI.Menu.Clone(mnuMainSetAsDesktop));
 
                 // check if igcmdWin10.exe exists!

--- a/Source/ImageGlass/frmSetting.Designer.cs
+++ b/Source/ImageGlass/frmSetting.Designer.cs
@@ -77,6 +77,7 @@ namespace ImageGlass
             this.chkWelcomePicture = new System.Windows.Forms.CheckBox();
             this.chkAutoUpdate = new System.Windows.Forms.CheckBox();
             this.tabImage = new System.Windows.Forms.TabPage();
+            this.chkShowSetDesktopInContext = new System.Windows.Forms.CheckBox();
             this.chkAutoDisplayNewImage = new System.Windows.Forms.CheckBox();
             this.numHorzPanningSpeed = new System.Windows.Forms.NumericUpDown();
             this.numVertPanningSpeed = new System.Windows.Forms.NumericUpDown();
@@ -231,6 +232,7 @@ namespace ImageGlass
             this.lvTheme = new System.Windows.Forms.ListView();
             this.btnThemeApply = new System.Windows.Forms.Button();
             this.tabLanguage = new System.Windows.Forms.TabPage();
+            this.lblTranslatorNames = new System.Windows.Forms.Label();
             this.lblTranslators = new System.Windows.Forms.Label();
             this.lblLanguageWarning = new System.Windows.Forms.Label();
             this.lnkInstallLanguage = new System.Windows.Forms.LinkLabel();
@@ -245,7 +247,6 @@ namespace ImageGlass
             this.btnApply = new System.Windows.Forms.Button();
             this.tblayout = new System.Windows.Forms.TableLayoutPanel();
             this.panel4 = new System.Windows.Forms.Panel();
-            this.lblTranslatorNames = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.picBackgroundColor)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.sp1)).BeginInit();
             this.sp1.Panel1.SuspendLayout();
@@ -297,11 +298,11 @@ namespace ImageGlass
             // 
             this.lblLanguage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblLanguage.Location = new System.Drawing.Point(0, 368);
+            this.lblLanguage.Location = new System.Drawing.Point(0, 392);
             this.lblLanguage.Margin = new System.Windows.Forms.Padding(0);
             this.lblLanguage.Name = "lblLanguage";
-            this.lblLanguage.Padding = new System.Windows.Forms.Padding(12, 0, 12, 0);
-            this.lblLanguage.Size = new System.Drawing.Size(236, 46);
+            this.lblLanguage.Padding = new System.Windows.Forms.Padding(13, 0, 13, 0);
+            this.lblLanguage.Size = new System.Drawing.Size(254, 49);
             this.lblLanguage.TabIndex = 9;
             this.lblLanguage.Tag = "0";
             this.lblLanguage.Text = "[Language]";
@@ -316,11 +317,11 @@ namespace ImageGlass
             // 
             this.lblFileTypeAssoc.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblFileTypeAssoc.Location = new System.Drawing.Point(0, 138);
+            this.lblFileTypeAssoc.Location = new System.Drawing.Point(0, 147);
             this.lblFileTypeAssoc.Margin = new System.Windows.Forms.Padding(0);
             this.lblFileTypeAssoc.Name = "lblFileTypeAssoc";
-            this.lblFileTypeAssoc.Padding = new System.Windows.Forms.Padding(12, 0, 12, 0);
-            this.lblFileTypeAssoc.Size = new System.Drawing.Size(236, 46);
+            this.lblFileTypeAssoc.Padding = new System.Windows.Forms.Padding(13, 0, 13, 0);
+            this.lblFileTypeAssoc.Size = new System.Drawing.Size(254, 49);
             this.lblFileTypeAssoc.TabIndex = 4;
             this.lblFileTypeAssoc.Tag = "0";
             this.lblFileTypeAssoc.Text = "[File Type Associations]";
@@ -339,8 +340,8 @@ namespace ImageGlass
             this.lblGeneral.Location = new System.Drawing.Point(0, 0);
             this.lblGeneral.Margin = new System.Windows.Forms.Padding(0);
             this.lblGeneral.Name = "lblGeneral";
-            this.lblGeneral.Padding = new System.Windows.Forms.Padding(12, 0, 12, 0);
-            this.lblGeneral.Size = new System.Drawing.Size(236, 46);
+            this.lblGeneral.Padding = new System.Windows.Forms.Padding(13, 0, 13, 0);
+            this.lblGeneral.Size = new System.Drawing.Size(254, 49);
             this.lblGeneral.TabIndex = 1;
             this.lblGeneral.Tag = "1";
             this.lblGeneral.Text = "General";
@@ -356,10 +357,10 @@ namespace ImageGlass
             this.picBackgroundColor.BackColor = System.Drawing.Color.White;
             this.picBackgroundColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.picBackgroundColor.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.picBackgroundColor.Location = new System.Drawing.Point(44, 519);
+            this.picBackgroundColor.Location = new System.Drawing.Point(47, 558);
             this.picBackgroundColor.Margin = new System.Windows.Forms.Padding(1);
             this.picBackgroundColor.Name = "picBackgroundColor";
-            this.picBackgroundColor.Size = new System.Drawing.Size(92, 37);
+            this.picBackgroundColor.Size = new System.Drawing.Size(99, 40);
             this.picBackgroundColor.TabIndex = 12;
             this.picBackgroundColor.TabStop = false;
             this.tip1.SetToolTip(this.picBackgroundColor, "Change background color");
@@ -394,8 +395,8 @@ namespace ImageGlass
             // 
             this.sp1.Panel2.BackColor = System.Drawing.Color.Transparent;
             this.sp1.Panel2.Controls.Add(this.tab1);
-            this.sp1.Size = new System.Drawing.Size(973, 669);
-            this.sp1.SplitterDistance = 217;
+            this.sp1.Size = new System.Drawing.Size(1046, 719);
+            this.sp1.SplitterDistance = 233;
             this.sp1.TabIndex = 17;
             this.sp1.TabStop = false;
             // 
@@ -403,7 +404,7 @@ namespace ImageGlass
             // 
             this.tableTabHeaders.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(160)))), ((int)(((byte)(165)))), ((int)(((byte)(168)))));
             this.tableTabHeaders.ColumnCount = 1;
-            this.tableTabHeaders.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 236F));
+            this.tableTabHeaders.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 254F));
             this.tableTabHeaders.Controls.Add(this.lblGeneral, 0, 0);
             this.tableTabHeaders.Controls.Add(this.lblImage, 0, 1);
             this.tableTabHeaders.Controls.Add(this.lblToolbar, 0, 4);
@@ -431,19 +432,19 @@ namespace ImageGlass
             this.tableTabHeaders.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableTabHeaders.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableTabHeaders.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableTabHeaders.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 21F));
-            this.tableTabHeaders.Size = new System.Drawing.Size(217, 669);
+            this.tableTabHeaders.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
+            this.tableTabHeaders.Size = new System.Drawing.Size(233, 719);
             this.tableTabHeaders.TabIndex = 5;
             // 
             // lblImage
             // 
             this.lblImage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblImage.Location = new System.Drawing.Point(0, 46);
+            this.lblImage.Location = new System.Drawing.Point(0, 49);
             this.lblImage.Margin = new System.Windows.Forms.Padding(0);
             this.lblImage.Name = "lblImage";
-            this.lblImage.Padding = new System.Windows.Forms.Padding(12, 0, 12, 0);
-            this.lblImage.Size = new System.Drawing.Size(236, 46);
+            this.lblImage.Padding = new System.Windows.Forms.Padding(13, 0, 13, 0);
+            this.lblImage.Size = new System.Drawing.Size(254, 49);
             this.lblImage.TabIndex = 2;
             this.lblImage.Tag = "0";
             this.lblImage.Text = "Image";
@@ -458,11 +459,11 @@ namespace ImageGlass
             // 
             this.lblToolbar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblToolbar.Location = new System.Drawing.Point(0, 184);
+            this.lblToolbar.Location = new System.Drawing.Point(0, 196);
             this.lblToolbar.Margin = new System.Windows.Forms.Padding(0);
             this.lblToolbar.Name = "lblToolbar";
-            this.lblToolbar.Padding = new System.Windows.Forms.Padding(12, 0, 12, 0);
-            this.lblToolbar.Size = new System.Drawing.Size(236, 46);
+            this.lblToolbar.Padding = new System.Windows.Forms.Padding(13, 0, 13, 0);
+            this.lblToolbar.Size = new System.Drawing.Size(254, 49);
             this.lblToolbar.TabIndex = 5;
             this.lblToolbar.Tag = "0";
             this.lblToolbar.Text = "Toolbar";
@@ -477,11 +478,11 @@ namespace ImageGlass
             // 
             this.lblTools.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblTools.Location = new System.Drawing.Point(0, 230);
+            this.lblTools.Location = new System.Drawing.Point(0, 245);
             this.lblTools.Margin = new System.Windows.Forms.Padding(0);
             this.lblTools.Name = "lblTools";
-            this.lblTools.Padding = new System.Windows.Forms.Padding(12, 0, 12, 0);
-            this.lblTools.Size = new System.Drawing.Size(236, 46);
+            this.lblTools.Padding = new System.Windows.Forms.Padding(13, 0, 13, 0);
+            this.lblTools.Size = new System.Drawing.Size(254, 49);
             this.lblTools.TabIndex = 6;
             this.lblTools.Tag = "0";
             this.lblTools.Text = "[Tools]";
@@ -496,11 +497,11 @@ namespace ImageGlass
             // 
             this.lblEdit.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblEdit.Location = new System.Drawing.Point(0, 92);
+            this.lblEdit.Location = new System.Drawing.Point(0, 98);
             this.lblEdit.Margin = new System.Windows.Forms.Padding(0);
             this.lblEdit.Name = "lblEdit";
-            this.lblEdit.Padding = new System.Windows.Forms.Padding(12, 0, 12, 0);
-            this.lblEdit.Size = new System.Drawing.Size(236, 46);
+            this.lblEdit.Padding = new System.Windows.Forms.Padding(13, 0, 13, 0);
+            this.lblEdit.Size = new System.Drawing.Size(254, 49);
             this.lblEdit.TabIndex = 3;
             this.lblEdit.Tag = "0";
             this.lblEdit.Text = "[Edit]";
@@ -515,11 +516,11 @@ namespace ImageGlass
             // 
             this.lblKeyboard.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblKeyboard.Location = new System.Drawing.Point(0, 276);
+            this.lblKeyboard.Location = new System.Drawing.Point(0, 294);
             this.lblKeyboard.Margin = new System.Windows.Forms.Padding(0);
             this.lblKeyboard.Name = "lblKeyboard";
-            this.lblKeyboard.Padding = new System.Windows.Forms.Padding(12, 0, 12, 0);
-            this.lblKeyboard.Size = new System.Drawing.Size(236, 46);
+            this.lblKeyboard.Padding = new System.Windows.Forms.Padding(13, 0, 13, 0);
+            this.lblKeyboard.Size = new System.Drawing.Size(254, 49);
             this.lblKeyboard.TabIndex = 7;
             this.lblKeyboard.Tag = "0";
             this.lblKeyboard.Text = "[Keyboard]";
@@ -534,11 +535,11 @@ namespace ImageGlass
             // 
             this.lblTheme.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblTheme.Location = new System.Drawing.Point(0, 322);
+            this.lblTheme.Location = new System.Drawing.Point(0, 343);
             this.lblTheme.Margin = new System.Windows.Forms.Padding(0);
             this.lblTheme.Name = "lblTheme";
-            this.lblTheme.Padding = new System.Windows.Forms.Padding(12, 0, 12, 0);
-            this.lblTheme.Size = new System.Drawing.Size(236, 46);
+            this.lblTheme.Padding = new System.Windows.Forms.Padding(13, 0, 13, 0);
+            this.lblTheme.Size = new System.Drawing.Size(254, 49);
             this.lblTheme.TabIndex = 8;
             this.lblTheme.Tag = "0";
             this.lblTheme.Text = "[Theme]";
@@ -568,7 +569,7 @@ namespace ImageGlass
             this.tab1.Name = "tab1";
             this.tab1.Padding = new System.Drawing.Point(0, 0);
             this.tab1.SelectedIndex = 0;
-            this.tab1.Size = new System.Drawing.Size(752, 669);
+            this.tab1.Size = new System.Drawing.Size(809, 719);
             this.tab1.SizeMode = System.Windows.Forms.TabSizeMode.Fixed;
             this.tab1.TabIndex = 0;
             this.tab1.SelectedIndexChanged += new System.EventHandler(this.tab1_SelectedIndexChanged);
@@ -602,11 +603,11 @@ namespace ImageGlass
             this.tabGeneral.Controls.Add(this.lblBackGroundColor);
             this.tabGeneral.Controls.Add(this.chkWelcomePicture);
             this.tabGeneral.Controls.Add(this.chkAutoUpdate);
-            this.tabGeneral.Location = new System.Drawing.Point(4, 69);
-            this.tabGeneral.Margin = new System.Windows.Forms.Padding(0, 0, 0, 50);
+            this.tabGeneral.Location = new System.Drawing.Point(4, 73);
+            this.tabGeneral.Margin = new System.Windows.Forms.Padding(0, 0, 0, 54);
             this.tabGeneral.Name = "tabGeneral";
-            this.tabGeneral.Padding = new System.Windows.Forms.Padding(0, 0, 0, 50);
-            this.tabGeneral.Size = new System.Drawing.Size(744, 596);
+            this.tabGeneral.Padding = new System.Windows.Forms.Padding(0, 0, 0, 54);
+            this.tabGeneral.Size = new System.Drawing.Size(801, 642);
             this.tabGeneral.TabIndex = 0;
             this.tabGeneral.Text = "general";
             // 
@@ -614,10 +615,10 @@ namespace ImageGlass
             // 
             this.chkStartWithOs.AutoSize = true;
             this.chkStartWithOs.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkStartWithOs.Location = new System.Drawing.Point(44, 634);
+            this.chkStartWithOs.Location = new System.Drawing.Point(47, 681);
             this.chkStartWithOs.Margin = new System.Windows.Forms.Padding(1);
             this.chkStartWithOs.Name = "chkStartWithOs";
-            this.chkStartWithOs.Size = new System.Drawing.Size(263, 28);
+            this.chkStartWithOs.Size = new System.Drawing.Size(277, 30);
             this.chkStartWithOs.TabIndex = 13;
             this.chkStartWithOs.Text = "[Start with operating system]";
             this.chkStartWithOs.UseVisualStyleBackColor = true;
@@ -626,10 +627,10 @@ namespace ImageGlass
             // 
             this.chkContinueRunningBackground.AutoSize = true;
             this.chkContinueRunningBackground.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkContinueRunningBackground.Location = new System.Drawing.Point(44, 667);
+            this.chkContinueRunningBackground.Location = new System.Drawing.Point(47, 717);
             this.chkContinueRunningBackground.Margin = new System.Windows.Forms.Padding(1);
             this.chkContinueRunningBackground.Name = "chkContinueRunningBackground";
-            this.chkContinueRunningBackground.Size = new System.Drawing.Size(465, 28);
+            this.chkContinueRunningBackground.Size = new System.Drawing.Size(484, 30);
             this.chkContinueRunningBackground.TabIndex = 14;
             this.chkContinueRunningBackground.Text = "[Continue running background when the app is closed]";
             this.chkContinueRunningBackground.UseVisualStyleBackColor = true;
@@ -639,10 +640,10 @@ namespace ImageGlass
             this.chkUseTouchGesture.AutoSize = true;
             this.chkUseTouchGesture.BackColor = System.Drawing.Color.Transparent;
             this.chkUseTouchGesture.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkUseTouchGesture.Location = new System.Drawing.Point(44, 451);
+            this.chkUseTouchGesture.Location = new System.Drawing.Point(47, 485);
             this.chkUseTouchGesture.Margin = new System.Windows.Forms.Padding(1);
             this.chkUseTouchGesture.Name = "chkUseTouchGesture";
-            this.chkUseTouchGesture.Size = new System.Drawing.Size(281, 28);
+            this.chkUseTouchGesture.Size = new System.Drawing.Size(294, 30);
             this.chkUseTouchGesture.TabIndex = 11;
             this.chkUseTouchGesture.Text = "[Enable touch gesture support]";
             this.chkUseTouchGesture.UseVisualStyleBackColor = false;
@@ -651,10 +652,10 @@ namespace ImageGlass
             // 
             this.lblHeadViewer.AutoSize = true;
             this.lblHeadViewer.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadViewer.Location = new System.Drawing.Point(22, 279);
+            this.lblHeadViewer.Location = new System.Drawing.Point(24, 300);
             this.lblHeadViewer.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadViewer.Name = "lblHeadViewer";
-            this.lblHeadViewer.Size = new System.Drawing.Size(77, 23);
+            this.lblHeadViewer.Size = new System.Drawing.Size(84, 25);
             this.lblHeadViewer.TabIndex = 47;
             this.lblHeadViewer.Text = "[Viewer]";
             // 
@@ -662,10 +663,10 @@ namespace ImageGlass
             // 
             this.chkShowToast.AutoSize = true;
             this.chkShowToast.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkShowToast.Location = new System.Drawing.Point(44, 874);
+            this.chkShowToast.Location = new System.Drawing.Point(47, 939);
             this.chkShowToast.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowToast.Name = "chkShowToast";
-            this.chkShowToast.Size = new System.Drawing.Size(210, 28);
+            this.chkShowToast.Size = new System.Drawing.Size(224, 30);
             this.chkShowToast.TabIndex = 20;
             this.chkShowToast.Text = "[Show toast message]";
             this.chkShowToast.UseVisualStyleBackColor = true;
@@ -674,10 +675,10 @@ namespace ImageGlass
             // 
             this.chkCenterWindowFit.AutoSize = true;
             this.chkCenterWindowFit.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkCenterWindowFit.Location = new System.Drawing.Point(44, 840);
+            this.chkCenterWindowFit.Location = new System.Drawing.Point(47, 903);
             this.chkCenterWindowFit.Margin = new System.Windows.Forms.Padding(1);
             this.chkCenterWindowFit.Name = "chkCenterWindowFit";
-            this.chkCenterWindowFit.Size = new System.Drawing.Size(396, 28);
+            this.chkCenterWindowFit.Size = new System.Drawing.Size(415, 30);
             this.chkCenterWindowFit.TabIndex = 19;
             this.chkCenterWindowFit.Text = "[Auto center the window in Window Fit mode]";
             this.chkCenterWindowFit.UseVisualStyleBackColor = true;
@@ -686,10 +687,10 @@ namespace ImageGlass
             // 
             this.chkShowCheckerboardOnlyImage.AutoSize = true;
             this.chkShowCheckerboardOnlyImage.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkShowCheckerboardOnlyImage.Location = new System.Drawing.Point(44, 414);
+            this.chkShowCheckerboardOnlyImage.Location = new System.Drawing.Point(47, 445);
             this.chkShowCheckerboardOnlyImage.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowCheckerboardOnlyImage.Name = "chkShowCheckerboardOnlyImage";
-            this.chkShowCheckerboardOnlyImage.Size = new System.Drawing.Size(409, 28);
+            this.chkShowCheckerboardOnlyImage.Size = new System.Drawing.Size(428, 30);
             this.chkShowCheckerboardOnlyImage.TabIndex = 10;
             this.chkShowCheckerboardOnlyImage.Text = "[Display checkerboard only in the image region]";
             this.chkShowCheckerboardOnlyImage.UseVisualStyleBackColor = true;
@@ -698,10 +699,10 @@ namespace ImageGlass
             // 
             this.chkShowNavButtons.AutoSize = true;
             this.chkShowNavButtons.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkShowNavButtons.Location = new System.Drawing.Point(44, 346);
+            this.chkShowNavButtons.Location = new System.Drawing.Point(47, 372);
             this.chkShowNavButtons.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowNavButtons.Name = "chkShowNavButtons";
-            this.chkShowNavButtons.Size = new System.Drawing.Size(306, 28);
+            this.chkShowNavButtons.Size = new System.Drawing.Size(323, 30);
             this.chkShowNavButtons.TabIndex = 8;
             this.chkShowNavButtons.Text = "[Display navigation arrow buttons]";
             this.chkShowNavButtons.UseVisualStyleBackColor = true;
@@ -710,10 +711,10 @@ namespace ImageGlass
             // 
             this.chkLastSeenImage.AutoSize = true;
             this.chkLastSeenImage.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkLastSeenImage.Location = new System.Drawing.Point(44, 89);
+            this.chkLastSeenImage.Location = new System.Drawing.Point(47, 96);
             this.chkLastSeenImage.Margin = new System.Windows.Forms.Padding(1);
             this.chkLastSeenImage.Name = "chkLastSeenImage";
-            this.chkLastSeenImage.Size = new System.Drawing.Size(250, 28);
+            this.chkLastSeenImage.Size = new System.Drawing.Size(261, 30);
             this.chkLastSeenImage.TabIndex = 4;
             this.chkLastSeenImage.Text = "[Open the last seen image]";
             this.chkLastSeenImage.UseVisualStyleBackColor = true;
@@ -724,10 +725,10 @@ namespace ImageGlass
             this.lnkConfigDir.AutoSize = true;
             this.lnkConfigDir.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkConfigDir.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkConfigDir.Location = new System.Drawing.Point(44, 213);
+            this.lnkConfigDir.Location = new System.Drawing.Point(47, 229);
             this.lnkConfigDir.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkConfigDir.Name = "lnkConfigDir";
-            this.lnkConfigDir.Size = new System.Drawing.Size(108, 23);
+            this.lnkConfigDir.Size = new System.Drawing.Size(115, 25);
             this.lnkConfigDir.TabIndex = 6;
             this.lnkConfigDir.TabStop = true;
             this.lnkConfigDir.Text = "[C:\\ABC\\XYZ]";
@@ -738,10 +739,10 @@ namespace ImageGlass
             // 
             this.chkDisplayBasename.AutoSize = true;
             this.chkDisplayBasename.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkDisplayBasename.Location = new System.Drawing.Point(44, 381);
+            this.chkDisplayBasename.Location = new System.Drawing.Point(47, 409);
             this.chkDisplayBasename.Margin = new System.Windows.Forms.Padding(1);
             this.chkDisplayBasename.Name = "chkDisplayBasename";
-            this.chkDisplayBasename.Size = new System.Drawing.Size(450, 28);
+            this.chkDisplayBasename.Size = new System.Drawing.Size(471, 30);
             this.chkDisplayBasename.TabIndex = 9;
             this.chkDisplayBasename.Text = "[Display base name of the viewing image on title bar]";
             this.chkDisplayBasename.UseVisualStyleBackColor = true;
@@ -750,10 +751,10 @@ namespace ImageGlass
             // 
             this.chkShowScrollbar.AutoSize = true;
             this.chkShowScrollbar.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkShowScrollbar.Location = new System.Drawing.Point(44, 313);
+            this.chkShowScrollbar.Location = new System.Drawing.Point(47, 336);
             this.chkShowScrollbar.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowScrollbar.Name = "chkShowScrollbar";
-            this.chkShowScrollbar.Size = new System.Drawing.Size(228, 28);
+            this.chkShowScrollbar.Size = new System.Drawing.Size(243, 30);
             this.chkShowScrollbar.TabIndex = 7;
             this.chkShowScrollbar.Text = "Display viewer scrollbars";
             this.chkShowScrollbar.UseVisualStyleBackColor = true;
@@ -764,10 +765,10 @@ namespace ImageGlass
             this.lnkResetBackgroundColor.AutoSize = true;
             this.lnkResetBackgroundColor.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkResetBackgroundColor.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkResetBackgroundColor.Location = new System.Drawing.Point(140, 529);
+            this.lnkResetBackgroundColor.Location = new System.Drawing.Point(150, 568);
             this.lnkResetBackgroundColor.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkResetBackgroundColor.Name = "lnkResetBackgroundColor";
-            this.lnkResetBackgroundColor.Size = new System.Drawing.Size(51, 23);
+            this.lnkResetBackgroundColor.Size = new System.Drawing.Size(54, 25);
             this.lnkResetBackgroundColor.TabIndex = 12;
             this.lnkResetBackgroundColor.TabStop = true;
             this.lnkResetBackgroundColor.Text = "Reset";
@@ -778,10 +779,10 @@ namespace ImageGlass
             // 
             this.lblHeadOthers.AutoSize = true;
             this.lblHeadOthers.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadOthers.Location = new System.Drawing.Point(22, 600);
+            this.lblHeadOthers.Location = new System.Drawing.Point(24, 645);
             this.lblHeadOthers.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadOthers.Name = "lblHeadOthers";
-            this.lblHeadOthers.Size = new System.Drawing.Size(63, 23);
+            this.lblHeadOthers.Size = new System.Drawing.Size(69, 25);
             this.lblHeadOthers.TabIndex = 46;
             this.lblHeadOthers.Text = "Others";
             // 
@@ -789,10 +790,10 @@ namespace ImageGlass
             // 
             this.lblHeadConfigDir.AutoSize = true;
             this.lblHeadConfigDir.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadConfigDir.Location = new System.Drawing.Point(22, 182);
+            this.lblHeadConfigDir.Location = new System.Drawing.Point(24, 196);
             this.lblHeadConfigDir.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadConfigDir.Name = "lblHeadConfigDir";
-            this.lblHeadConfigDir.Size = new System.Drawing.Size(213, 23);
+            this.lblHeadConfigDir.Size = new System.Drawing.Size(227, 25);
             this.lblHeadConfigDir.TabIndex = 45;
             this.lblHeadConfigDir.Text = "[Configuration directory]";
             // 
@@ -800,29 +801,29 @@ namespace ImageGlass
             // 
             this.lblHeadStartup.AutoSize = true;
             this.lblHeadStartup.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadStartup.Location = new System.Drawing.Point(22, 21);
+            this.lblHeadStartup.Location = new System.Drawing.Point(24, 23);
             this.lblHeadStartup.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadStartup.Name = "lblHeadStartup";
-            this.lblHeadStartup.Size = new System.Drawing.Size(76, 23);
+            this.lblHeadStartup.Size = new System.Drawing.Size(81, 25);
             this.lblHeadStartup.TabIndex = 44;
             this.lblHeadStartup.Text = "Start up";
             // 
             // panel1
             // 
-            this.panel1.Location = new System.Drawing.Point(291, 908);
+            this.panel1.Location = new System.Drawing.Point(313, 976);
             this.panel1.Margin = new System.Windows.Forms.Padding(1);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(102, 29);
+            this.panel1.Size = new System.Drawing.Size(110, 31);
             this.panel1.TabIndex = 24;
             // 
             // chkConfirmationDelete
             // 
             this.chkConfirmationDelete.AutoSize = true;
             this.chkConfirmationDelete.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkConfirmationDelete.Location = new System.Drawing.Point(44, 807);
+            this.chkConfirmationDelete.Location = new System.Drawing.Point(47, 867);
             this.chkConfirmationDelete.Margin = new System.Windows.Forms.Padding(1);
             this.chkConfirmationDelete.Name = "chkConfirmationDelete";
-            this.chkConfirmationDelete.Size = new System.Drawing.Size(312, 28);
+            this.chkConfirmationDelete.Size = new System.Drawing.Size(329, 30);
             this.chkConfirmationDelete.TabIndex = 18;
             this.chkConfirmationDelete.Text = "Display Delete confirmation dialog ";
             this.chkConfirmationDelete.UseVisualStyleBackColor = true;
@@ -831,10 +832,10 @@ namespace ImageGlass
             // 
             this.chkAllowMultiInstances.AutoSize = true;
             this.chkAllowMultiInstances.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkAllowMultiInstances.Location = new System.Drawing.Point(44, 736);
+            this.chkAllowMultiInstances.Location = new System.Drawing.Point(47, 791);
             this.chkAllowMultiInstances.Margin = new System.Windows.Forms.Padding(1);
             this.chkAllowMultiInstances.Name = "chkAllowMultiInstances";
-            this.chkAllowMultiInstances.Size = new System.Drawing.Size(349, 28);
+            this.chkAllowMultiInstances.Size = new System.Drawing.Size(367, 30);
             this.chkAllowMultiInstances.TabIndex = 16;
             this.chkAllowMultiInstances.Text = "Allow multiple instances of the program";
             this.chkAllowMultiInstances.UseVisualStyleBackColor = true;
@@ -843,10 +844,10 @@ namespace ImageGlass
             // 
             this.chkESCToQuit.AutoSize = true;
             this.chkESCToQuit.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkESCToQuit.Location = new System.Drawing.Point(44, 770);
+            this.chkESCToQuit.Location = new System.Drawing.Point(47, 827);
             this.chkESCToQuit.Margin = new System.Windows.Forms.Padding(1);
             this.chkESCToQuit.Name = "chkESCToQuit";
-            this.chkESCToQuit.Size = new System.Drawing.Size(330, 28);
+            this.chkESCToQuit.Size = new System.Drawing.Size(348, 30);
             this.chkESCToQuit.TabIndex = 17;
             this.chkESCToQuit.Text = "Allow to press ESC to quit application";
             this.chkESCToQuit.UseVisualStyleBackColor = true;
@@ -855,10 +856,10 @@ namespace ImageGlass
             // 
             this.chkShowToolBar.AutoSize = true;
             this.chkShowToolBar.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkShowToolBar.Location = new System.Drawing.Point(44, 124);
+            this.chkShowToolBar.Location = new System.Drawing.Point(47, 133);
             this.chkShowToolBar.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowToolBar.Name = "chkShowToolBar";
-            this.chkShowToolBar.Size = new System.Drawing.Size(280, 28);
+            this.chkShowToolBar.Size = new System.Drawing.Size(295, 30);
             this.chkShowToolBar.TabIndex = 5;
             this.chkShowToolBar.Text = "Show toolbar when starting up";
             this.chkShowToolBar.UseVisualStyleBackColor = true;
@@ -866,10 +867,10 @@ namespace ImageGlass
             // lblBackGroundColor
             // 
             this.lblBackGroundColor.AutoSize = true;
-            this.lblBackGroundColor.Location = new System.Drawing.Point(38, 497);
+            this.lblBackGroundColor.Location = new System.Drawing.Point(41, 534);
             this.lblBackGroundColor.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblBackGroundColor.Name = "lblBackGroundColor";
-            this.lblBackGroundColor.Size = new System.Drawing.Size(148, 23);
+            this.lblBackGroundColor.Size = new System.Drawing.Size(156, 25);
             this.lblBackGroundColor.TabIndex = 11;
             this.lblBackGroundColor.Text = "Background color:";
             // 
@@ -877,10 +878,10 @@ namespace ImageGlass
             // 
             this.chkWelcomePicture.AutoSize = true;
             this.chkWelcomePicture.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkWelcomePicture.Location = new System.Drawing.Point(44, 54);
+            this.chkWelcomePicture.Location = new System.Drawing.Point(47, 58);
             this.chkWelcomePicture.Margin = new System.Windows.Forms.Padding(1);
             this.chkWelcomePicture.Name = "chkWelcomePicture";
-            this.chkWelcomePicture.Size = new System.Drawing.Size(216, 28);
+            this.chkWelcomePicture.Size = new System.Drawing.Size(228, 30);
             this.chkWelcomePicture.TabIndex = 3;
             this.chkWelcomePicture.Text = "Show welcome picture";
             this.chkWelcomePicture.UseVisualStyleBackColor = true;
@@ -889,10 +890,10 @@ namespace ImageGlass
             // 
             this.chkAutoUpdate.AutoSize = true;
             this.chkAutoUpdate.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkAutoUpdate.Location = new System.Drawing.Point(44, 702);
+            this.chkAutoUpdate.Location = new System.Drawing.Point(47, 754);
             this.chkAutoUpdate.Margin = new System.Windows.Forms.Padding(1);
             this.chkAutoUpdate.Name = "chkAutoUpdate";
-            this.chkAutoUpdate.Size = new System.Drawing.Size(283, 28);
+            this.chkAutoUpdate.Size = new System.Drawing.Size(296, 30);
             this.chkAutoUpdate.TabIndex = 15;
             this.chkAutoUpdate.Text = "Check for update automatically";
             this.chkAutoUpdate.UseVisualStyleBackColor = true;
@@ -901,6 +902,7 @@ namespace ImageGlass
             // 
             this.tabImage.AutoScroll = true;
             this.tabImage.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(198)))), ((int)(((byte)(203)))), ((int)(((byte)(204)))));
+            this.tabImage.Controls.Add(this.chkShowSetDesktopInContext);
             this.tabImage.Controls.Add(this.chkAutoDisplayNewImage);
             this.tabImage.Controls.Add(this.numHorzPanningSpeed);
             this.tabImage.Controls.Add(this.numVertPanningSpeed);
@@ -958,21 +960,35 @@ namespace ImageGlass
             this.tabImage.Controls.Add(this.cmbImageOrder);
             this.tabImage.Controls.Add(this.lblSlideshowInterval);
             this.tabImage.Controls.Add(this.chkFindChildFolder);
-            this.tabImage.Location = new System.Drawing.Point(4, 69);
+            this.tabImage.Location = new System.Drawing.Point(4, 73);
             this.tabImage.Margin = new System.Windows.Forms.Padding(0);
             this.tabImage.Name = "tabImage";
-            this.tabImage.Size = new System.Drawing.Size(744, 596);
+            this.tabImage.Size = new System.Drawing.Size(801, 642);
             this.tabImage.TabIndex = 3;
             this.tabImage.Text = "Image";
+            // 
+            // chkShowSetDesktopInContext
+            // 
+            this.chkShowSetDesktopInContext.AutoSize = true;
+            this.chkShowSetDesktopInContext.Checked = true;
+            this.chkShowSetDesktopInContext.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkShowSetDesktopInContext.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.chkShowSetDesktopInContext.Location = new System.Drawing.Point(47, 411);
+            this.chkShowSetDesktopInContext.Margin = new System.Windows.Forms.Padding(1);
+            this.chkShowSetDesktopInContext.Name = "chkShowSetDesktopInContext";
+            this.chkShowSetDesktopInContext.Size = new System.Drawing.Size(591, 30);
+            this.chkShowSetDesktopInContext.TabIndex = 79;
+            this.chkShowSetDesktopInContext.Text = "[Show option to set image as desktop background in context menu]";
+            this.chkShowSetDesktopInContext.UseVisualStyleBackColor = true;
             // 
             // chkAutoDisplayNewImage
             // 
             this.chkAutoDisplayNewImage.AutoSize = true;
             this.chkAutoDisplayNewImage.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkAutoDisplayNewImage.Location = new System.Drawing.Point(44, 254);
+            this.chkAutoDisplayNewImage.Location = new System.Drawing.Point(47, 273);
             this.chkAutoDisplayNewImage.Margin = new System.Windows.Forms.Padding(1);
             this.chkAutoDisplayNewImage.Name = "chkAutoDisplayNewImage";
-            this.chkAutoDisplayNewImage.Size = new System.Drawing.Size(372, 28);
+            this.chkAutoDisplayNewImage.Size = new System.Drawing.Size(390, 30);
             this.chkAutoDisplayNewImage.TabIndex = 22;
             this.chkAutoDisplayNewImage.Text = "[Display new image in folder automatically]";
             this.chkAutoDisplayNewImage.UseVisualStyleBackColor = true;
@@ -980,38 +996,38 @@ namespace ImageGlass
             // numHorzPanningSpeed
             // 
             this.numHorzPanningSpeed.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
-            this.numHorzPanningSpeed.Location = new System.Drawing.Point(44, 1307);
+            this.numHorzPanningSpeed.Location = new System.Drawing.Point(47, 1444);
             this.numHorzPanningSpeed.Margin = new System.Windows.Forms.Padding(4);
             this.numHorzPanningSpeed.Name = "numHorzPanningSpeed";
-            this.numHorzPanningSpeed.Size = new System.Drawing.Size(107, 30);
+            this.numHorzPanningSpeed.Size = new System.Drawing.Size(115, 31);
             this.numHorzPanningSpeed.TabIndex = 38;
             // 
             // numVertPanningSpeed
             // 
             this.numVertPanningSpeed.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
-            this.numVertPanningSpeed.Location = new System.Drawing.Point(42, 1232);
+            this.numVertPanningSpeed.Location = new System.Drawing.Point(45, 1363);
             this.numVertPanningSpeed.Margin = new System.Windows.Forms.Padding(4);
             this.numVertPanningSpeed.Name = "numVertPanningSpeed";
-            this.numVertPanningSpeed.Size = new System.Drawing.Size(107, 30);
+            this.numVertPanningSpeed.Size = new System.Drawing.Size(115, 31);
             this.numVertPanningSpeed.TabIndex = 37;
             // 
             // lblHorzPanningSpeed
             // 
             this.lblHorzPanningSpeed.AutoSize = true;
-            this.lblHorzPanningSpeed.Location = new System.Drawing.Point(38, 1280);
+            this.lblHorzPanningSpeed.Location = new System.Drawing.Point(41, 1415);
             this.lblHorzPanningSpeed.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHorzPanningSpeed.Name = "lblHorzPanningSpeed";
-            this.lblHorzPanningSpeed.Size = new System.Drawing.Size(221, 23);
+            this.lblHorzPanningSpeed.Size = new System.Drawing.Size(231, 25);
             this.lblHorzPanningSpeed.TabIndex = 78;
             this.lblHorzPanningSpeed.Text = "[Horizontal panning speed:]";
             // 
             // lblVertPanningSpeed
             // 
             this.lblVertPanningSpeed.AutoSize = true;
-            this.lblVertPanningSpeed.Location = new System.Drawing.Point(38, 1205);
+            this.lblVertPanningSpeed.Location = new System.Drawing.Point(41, 1334);
             this.lblVertPanningSpeed.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblVertPanningSpeed.Name = "lblVertPanningSpeed";
-            this.lblVertPanningSpeed.Size = new System.Drawing.Size(198, 23);
+            this.lblVertPanningSpeed.Size = new System.Drawing.Size(205, 25);
             this.lblVertPanningSpeed.TabIndex = 77;
             this.lblVertPanningSpeed.Text = "[Vertical panning speed:]";
             // 
@@ -1019,40 +1035,40 @@ namespace ImageGlass
             // 
             this.lblHeadPanning.AutoSize = true;
             this.lblHeadPanning.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadPanning.Location = new System.Drawing.Point(22, 1169);
+            this.lblHeadPanning.Location = new System.Drawing.Point(24, 1295);
             this.lblHeadPanning.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadPanning.Name = "lblHeadPanning";
-            this.lblHeadPanning.Size = new System.Drawing.Size(87, 23);
+            this.lblHeadPanning.Size = new System.Drawing.Size(96, 25);
             this.lblHeadPanning.TabIndex = 76;
             this.lblHeadPanning.Text = "[Panning]";
             // 
             // lblNumberImagesNotify
             // 
             this.lblNumberImagesNotify.AutoSize = true;
-            this.lblNumberImagesNotify.Location = new System.Drawing.Point(60, 325);
+            this.lblNumberImagesNotify.Location = new System.Drawing.Point(64, 344);
             this.lblNumberImagesNotify.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblNumberImagesNotify.Name = "lblNumberImagesNotify";
-            this.lblNumberImagesNotify.Size = new System.Drawing.Size(231, 23);
+            this.lblNumberImagesNotify.Size = new System.Drawing.Size(244, 25);
             this.lblNumberImagesNotify.TabIndex = 75;
             this.lblNumberImagesNotify.Text = "[Number of images to nofity]";
             // 
             // numNumberImagesNotify
             // 
             this.numNumberImagesNotify.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
-            this.numNumberImagesNotify.Location = new System.Drawing.Point(63, 352);
+            this.numNumberImagesNotify.Location = new System.Drawing.Point(68, 373);
             this.numNumberImagesNotify.Margin = new System.Windows.Forms.Padding(4);
             this.numNumberImagesNotify.Name = "numNumberImagesNotify";
-            this.numNumberImagesNotify.Size = new System.Drawing.Size(107, 30);
+            this.numNumberImagesNotify.Size = new System.Drawing.Size(115, 31);
             this.numNumberImagesNotify.TabIndex = 24;
             // 
             // chkIsPlayImageChangeSound
             // 
             this.chkIsPlayImageChangeSound.AutoSize = true;
             this.chkIsPlayImageChangeSound.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkIsPlayImageChangeSound.Location = new System.Drawing.Point(44, 288);
+            this.chkIsPlayImageChangeSound.Location = new System.Drawing.Point(47, 309);
             this.chkIsPlayImageChangeSound.Margin = new System.Windows.Forms.Padding(1);
             this.chkIsPlayImageChangeSound.Name = "chkIsPlayImageChangeSound";
-            this.chkIsPlayImageChangeSound.Size = new System.Drawing.Size(304, 28);
+            this.chkIsPlayImageChangeSound.Size = new System.Drawing.Size(318, 30);
             this.chkIsPlayImageChangeSound.TabIndex = 23;
             this.chkIsPlayImageChangeSound.Text = "[Play sound when image changes]";
             this.chkIsPlayImageChangeSound.UseVisualStyleBackColor = true;
@@ -1061,10 +1077,10 @@ namespace ImageGlass
             // 
             this.chkHideThumbnailBarInFullScreen.AutoSize = true;
             this.chkHideThumbnailBarInFullScreen.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkHideThumbnailBarInFullScreen.Location = new System.Drawing.Point(44, 2160);
+            this.chkHideThumbnailBarInFullScreen.Location = new System.Drawing.Point(47, 2360);
             this.chkHideThumbnailBarInFullScreen.Margin = new System.Windows.Forms.Padding(1);
             this.chkHideThumbnailBarInFullScreen.Name = "chkHideThumbnailBarInFullScreen";
-            this.chkHideThumbnailBarInFullScreen.Size = new System.Drawing.Size(203, 28);
+            this.chkHideThumbnailBarInFullScreen.Size = new System.Drawing.Size(213, 30);
             this.chkHideThumbnailBarInFullScreen.TabIndex = 50;
             this.chkHideThumbnailBarInFullScreen.Text = "[Hide thumbnail bar]";
             this.chkHideThumbnailBarInFullScreen.UseVisualStyleBackColor = true;
@@ -1073,10 +1089,10 @@ namespace ImageGlass
             // 
             this.lblHeadFullScreen.AutoSize = true;
             this.lblHeadFullScreen.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadFullScreen.Location = new System.Drawing.Point(22, 2092);
+            this.lblHeadFullScreen.Location = new System.Drawing.Point(24, 2287);
             this.lblHeadFullScreen.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadFullScreen.Name = "lblHeadFullScreen";
-            this.lblHeadFullScreen.Size = new System.Drawing.Size(106, 23);
+            this.lblHeadFullScreen.Size = new System.Drawing.Size(116, 25);
             this.lblHeadFullScreen.TabIndex = 72;
             this.lblHeadFullScreen.Text = "[Full screen]";
             // 
@@ -1084,10 +1100,10 @@ namespace ImageGlass
             // 
             this.chkHideToolbarInFullScreen.AutoSize = true;
             this.chkHideToolbarInFullScreen.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkHideToolbarInFullScreen.Location = new System.Drawing.Point(44, 2125);
+            this.chkHideToolbarInFullScreen.Location = new System.Drawing.Point(47, 2323);
             this.chkHideToolbarInFullScreen.Margin = new System.Windows.Forms.Padding(1);
             this.chkHideToolbarInFullScreen.Name = "chkHideToolbarInFullScreen";
-            this.chkHideToolbarInFullScreen.Size = new System.Drawing.Size(150, 28);
+            this.chkHideToolbarInFullScreen.Size = new System.Drawing.Size(160, 30);
             this.chkHideToolbarInFullScreen.TabIndex = 49;
             this.chkHideToolbarInFullScreen.Text = "[Hide toolbar]";
             this.chkHideToolbarInFullScreen.UseVisualStyleBackColor = true;
@@ -1096,10 +1112,10 @@ namespace ImageGlass
             // 
             this.chkIsUseRawThumbnail.AutoSize = true;
             this.chkIsUseRawThumbnail.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkIsUseRawThumbnail.Location = new System.Drawing.Point(44, 218);
+            this.chkIsUseRawThumbnail.Location = new System.Drawing.Point(47, 234);
             this.chkIsUseRawThumbnail.Margin = new System.Windows.Forms.Padding(1);
             this.chkIsUseRawThumbnail.Name = "chkIsUseRawThumbnail";
-            this.chkIsUseRawThumbnail.Size = new System.Drawing.Size(383, 28);
+            this.chkIsUseRawThumbnail.Size = new System.Drawing.Size(405, 30);
             this.chkIsUseRawThumbnail.TabIndex = 21;
             this.chkIsUseRawThumbnail.Text = "[Use embedded thumbnail for RAW formats]";
             this.chkIsUseRawThumbnail.UseVisualStyleBackColor = true;
@@ -1108,10 +1124,10 @@ namespace ImageGlass
             // 
             this.chkGroupByDirectory.AutoSize = true;
             this.chkGroupByDirectory.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkGroupByDirectory.Location = new System.Drawing.Point(44, 82);
+            this.chkGroupByDirectory.Location = new System.Drawing.Point(47, 88);
             this.chkGroupByDirectory.Margin = new System.Windows.Forms.Padding(1);
             this.chkGroupByDirectory.Name = "chkGroupByDirectory";
-            this.chkGroupByDirectory.Size = new System.Drawing.Size(257, 28);
+            this.chkGroupByDirectory.Size = new System.Drawing.Size(272, 30);
             this.chkGroupByDirectory.TabIndex = 17;
             this.chkGroupByDirectory.Text = "[Group images by directory]";
             this.chkGroupByDirectory.UseVisualStyleBackColor = true;
@@ -1126,12 +1142,12 @@ namespace ImageGlass
             this.tableLayoutPanel2.Controls.Add(this.numSlideShowInterval, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.lblSlideshowIntervalTo, 1, 0);
             this.tableLayoutPanel2.Controls.Add(this.numSlideshowIntervalTo, 2, 0);
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(63, 2010);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(68, 2199);
             this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(314, 55);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(337, 59);
             this.tableLayoutPanel2.TabIndex = 68;
             // 
             // numSlideShowInterval
@@ -1146,7 +1162,7 @@ namespace ImageGlass
             0,
             0});
             this.numSlideShowInterval.Name = "numSlideShowInterval";
-            this.numSlideShowInterval.Size = new System.Drawing.Size(107, 30);
+            this.numSlideShowInterval.Size = new System.Drawing.Size(115, 31);
             this.numSlideShowInterval.TabIndex = 47;
             this.numSlideShowInterval.Value = new decimal(new int[] {
             1,
@@ -1158,10 +1174,10 @@ namespace ImageGlass
             // lblSlideshowIntervalTo
             // 
             this.lblSlideshowIntervalTo.AutoSize = true;
-            this.lblSlideshowIntervalTo.Location = new System.Drawing.Point(116, 4);
+            this.lblSlideshowIntervalTo.Location = new System.Drawing.Point(124, 4);
             this.lblSlideshowIntervalTo.Margin = new System.Windows.Forms.Padding(1, 4, 1, 0);
             this.lblSlideshowIntervalTo.Name = "lblSlideshowIntervalTo";
-            this.lblSlideshowIntervalTo.Size = new System.Drawing.Size(36, 23);
+            this.lblSlideshowIntervalTo.Size = new System.Drawing.Size(39, 25);
             this.lblSlideshowIntervalTo.TabIndex = 69;
             this.lblSlideshowIntervalTo.Text = "[to]";
             this.lblSlideshowIntervalTo.Visible = false;
@@ -1170,7 +1186,7 @@ namespace ImageGlass
             // 
             this.numSlideshowIntervalTo.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
             this.numSlideshowIntervalTo.DecimalPlaces = 2;
-            this.numSlideshowIntervalTo.Location = new System.Drawing.Point(157, 4);
+            this.numSlideshowIntervalTo.Location = new System.Drawing.Point(168, 4);
             this.numSlideshowIntervalTo.Margin = new System.Windows.Forms.Padding(4);
             this.numSlideshowIntervalTo.Maximum = new decimal(new int[] {
             600,
@@ -1183,7 +1199,7 @@ namespace ImageGlass
             0,
             0});
             this.numSlideshowIntervalTo.Name = "numSlideshowIntervalTo";
-            this.numSlideshowIntervalTo.Size = new System.Drawing.Size(107, 30);
+            this.numSlideshowIntervalTo.Size = new System.Drawing.Size(115, 31);
             this.numSlideshowIntervalTo.TabIndex = 48;
             this.numSlideshowIntervalTo.Value = new decimal(new int[] {
             1,
@@ -1197,10 +1213,10 @@ namespace ImageGlass
             // 
             this.chkRandomSlideshowInterval.AutoSize = true;
             this.chkRandomSlideshowInterval.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkRandomSlideshowInterval.Location = new System.Drawing.Point(44, 1952);
+            this.chkRandomSlideshowInterval.Location = new System.Drawing.Point(47, 2137);
             this.chkRandomSlideshowInterval.Margin = new System.Windows.Forms.Padding(1);
             this.chkRandomSlideshowInterval.Name = "chkRandomSlideshowInterval";
-            this.chkRandomSlideshowInterval.Size = new System.Drawing.Size(209, 28);
+            this.chkRandomSlideshowInterval.Size = new System.Drawing.Size(219, 30);
             this.chkRandomSlideshowInterval.TabIndex = 46;
             this.chkRandomSlideshowInterval.Text = "[Use random interval]";
             this.chkRandomSlideshowInterval.UseVisualStyleBackColor = true;
@@ -1210,10 +1226,10 @@ namespace ImageGlass
             // 
             this.chkShowSlideshowCountdown.AutoSize = true;
             this.chkShowSlideshowCountdown.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkShowSlideshowCountdown.Location = new System.Drawing.Point(44, 1915);
+            this.chkShowSlideshowCountdown.Location = new System.Drawing.Point(47, 2097);
             this.chkShowSlideshowCountdown.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowSlideshowCountdown.Name = "chkShowSlideshowCountdown";
-            this.chkShowSlideshowCountdown.Size = new System.Drawing.Size(232, 28);
+            this.chkShowSlideshowCountdown.Size = new System.Drawing.Size(245, 30);
             this.chkShowSlideshowCountdown.TabIndex = 45;
             this.chkShowSlideshowCountdown.Text = "[Show countdown timer]";
             this.chkShowSlideshowCountdown.UseVisualStyleBackColor = true;
@@ -1222,10 +1238,10 @@ namespace ImageGlass
             // 
             this.chkIsCenterImage.AutoSize = true;
             this.chkIsCenterImage.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkIsCenterImage.Location = new System.Drawing.Point(44, 184);
+            this.chkIsCenterImage.Location = new System.Drawing.Point(47, 198);
             this.chkIsCenterImage.Margin = new System.Windows.Forms.Padding(1);
             this.chkIsCenterImage.Name = "chkIsCenterImage";
-            this.chkIsCenterImage.Size = new System.Drawing.Size(236, 28);
+            this.chkIsCenterImage.Size = new System.Drawing.Size(246, 30);
             this.chkIsCenterImage.TabIndex = 20;
             this.chkIsCenterImage.Text = "[Center image on viewer]";
             this.chkIsCenterImage.UseVisualStyleBackColor = true;
@@ -1233,10 +1249,10 @@ namespace ImageGlass
             // lblImageBoosterCachedCount
             // 
             this.lblImageBoosterCachedCount.AutoSize = true;
-            this.lblImageBoosterCachedCount.Location = new System.Drawing.Point(38, 517);
+            this.lblImageBoosterCachedCount.Location = new System.Drawing.Point(41, 595);
             this.lblImageBoosterCachedCount.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblImageBoosterCachedCount.Name = "lblImageBoosterCachedCount";
-            this.lblImageBoosterCachedCount.Size = new System.Drawing.Size(471, 23);
+            this.lblImageBoosterCachedCount.Size = new System.Drawing.Size(491, 25);
             this.lblImageBoosterCachedCount.TabIndex = 64;
             this.lblImageBoosterCachedCount.Text = "[Number of images cached by ImageBooster (one direction)]";
             // 
@@ -1257,31 +1273,31 @@ namespace ImageGlass
             "8",
             "9",
             "10"});
-            this.cmbImageBoosterCachedCount.Location = new System.Drawing.Point(44, 543);
+            this.cmbImageBoosterCachedCount.Location = new System.Drawing.Point(47, 623);
             this.cmbImageBoosterCachedCount.Margin = new System.Windows.Forms.Padding(1);
             this.cmbImageBoosterCachedCount.Name = "cmbImageBoosterCachedCount";
-            this.cmbImageBoosterCachedCount.Size = new System.Drawing.Size(260, 31);
+            this.cmbImageBoosterCachedCount.Size = new System.Drawing.Size(279, 33);
             this.cmbImageBoosterCachedCount.TabIndex = 28;
             // 
             // txtZoomLevels
             // 
             this.txtZoomLevels.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
-            this.txtZoomLevels.Location = new System.Drawing.Point(44, 1516);
+            this.txtZoomLevels.Location = new System.Drawing.Point(47, 1668);
             this.txtZoomLevels.Margin = new System.Windows.Forms.Padding(4);
             this.txtZoomLevels.Multiline = true;
             this.txtZoomLevels.Name = "txtZoomLevels";
             this.txtZoomLevels.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtZoomLevels.Size = new System.Drawing.Size(529, 81);
+            this.txtZoomLevels.Size = new System.Drawing.Size(568, 87);
             this.txtZoomLevels.TabIndex = 40;
             // 
             // lblZoomLevels
             // 
             this.lblZoomLevels.AutoSize = true;
             this.lblZoomLevels.BackColor = System.Drawing.Color.Transparent;
-            this.lblZoomLevels.Location = new System.Drawing.Point(38, 1489);
+            this.lblZoomLevels.Location = new System.Drawing.Point(41, 1639);
             this.lblZoomLevels.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblZoomLevels.Name = "lblZoomLevels";
-            this.lblZoomLevels.Size = new System.Drawing.Size(111, 23);
+            this.lblZoomLevels.Size = new System.Drawing.Size(118, 25);
             this.lblZoomLevels.TabIndex = 61;
             this.lblZoomLevels.Text = "[Zoom levels]";
             // 
@@ -1293,10 +1309,10 @@ namespace ImageGlass
             this.cmbImageOrderType.Items.AddRange(new object[] {
             "[Ascending]",
             "[Descending]"});
-            this.cmbImageOrderType.Location = new System.Drawing.Point(312, 423);
+            this.cmbImageOrderType.Location = new System.Drawing.Point(335, 494);
             this.cmbImageOrderType.Margin = new System.Windows.Forms.Padding(1);
             this.cmbImageOrderType.Name = "cmbImageOrderType";
-            this.cmbImageOrderType.Size = new System.Drawing.Size(260, 31);
+            this.cmbImageOrderType.Size = new System.Drawing.Size(279, 33);
             this.cmbImageOrderType.TabIndex = 26;
             // 
             // lnkColorProfilePath
@@ -1306,10 +1322,10 @@ namespace ImageGlass
             this.lnkColorProfilePath.BackColor = System.Drawing.Color.Transparent;
             this.lnkColorProfilePath.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkColorProfilePath.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkColorProfilePath.Location = new System.Drawing.Point(38, 761);
+            this.lnkColorProfilePath.Location = new System.Drawing.Point(41, 857);
             this.lnkColorProfilePath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkColorProfilePath.Name = "lnkColorProfilePath";
-            this.lnkColorProfilePath.Size = new System.Drawing.Size(144, 23);
+            this.lnkColorProfilePath.Size = new System.Drawing.Size(152, 25);
             this.lnkColorProfilePath.TabIndex = 32;
             this.lnkColorProfilePath.TabStop = true;
             this.lnkColorProfilePath.Text = "C:\\abc\\custom.icc";
@@ -1323,10 +1339,10 @@ namespace ImageGlass
             this.lnkColorProfileBrowse.BackColor = System.Drawing.Color.Transparent;
             this.lnkColorProfileBrowse.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkColorProfileBrowse.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkColorProfileBrowse.Location = new System.Drawing.Point(306, 726);
+            this.lnkColorProfileBrowse.Location = new System.Drawing.Point(329, 819);
             this.lnkColorProfileBrowse.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkColorProfileBrowse.Name = "lnkColorProfileBrowse";
-            this.lnkColorProfileBrowse.Size = new System.Drawing.Size(74, 23);
+            this.lnkColorProfileBrowse.Size = new System.Drawing.Size(79, 25);
             this.lnkColorProfileBrowse.TabIndex = 31;
             this.lnkColorProfileBrowse.TabStop = true;
             this.lnkColorProfileBrowse.Text = "[Browse]";
@@ -1337,10 +1353,10 @@ namespace ImageGlass
             // 
             this.lblColorManagement.AutoSize = true;
             this.lblColorManagement.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblColorManagement.Location = new System.Drawing.Point(22, 612);
+            this.lblColorManagement.Location = new System.Drawing.Point(24, 697);
             this.lblColorManagement.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblColorManagement.Name = "lblColorManagement";
-            this.lblColorManagement.Size = new System.Drawing.Size(176, 23);
+            this.lblColorManagement.Size = new System.Drawing.Size(188, 25);
             this.lblColorManagement.TabIndex = 59;
             this.lblColorManagement.Text = "[Color management]";
             // 
@@ -1348,10 +1364,10 @@ namespace ImageGlass
             // 
             this.chkApplyColorProfile.AutoSize = true;
             this.chkApplyColorProfile.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkApplyColorProfile.Location = new System.Drawing.Point(44, 644);
+            this.chkApplyColorProfile.Location = new System.Drawing.Point(47, 731);
             this.chkApplyColorProfile.Margin = new System.Windows.Forms.Padding(1);
             this.chkApplyColorProfile.Name = "chkApplyColorProfile";
-            this.chkApplyColorProfile.Size = new System.Drawing.Size(464, 28);
+            this.chkApplyColorProfile.Size = new System.Drawing.Size(492, 30);
             this.chkApplyColorProfile.TabIndex = 29;
             this.chkApplyColorProfile.Text = "[Apply also for images without embedded color profile]";
             this.chkApplyColorProfile.UseVisualStyleBackColor = true;
@@ -1364,10 +1380,10 @@ namespace ImageGlass
             this.cmbColorProfile.Items.AddRange(new object[] {
             "[None]",
             "[Custom ICC/ICM profile file:]"});
-            this.cmbColorProfile.Location = new System.Drawing.Point(44, 724);
+            this.cmbColorProfile.Location = new System.Drawing.Point(47, 817);
             this.cmbColorProfile.Margin = new System.Windows.Forms.Padding(1);
             this.cmbColorProfile.Name = "cmbColorProfile";
-            this.cmbColorProfile.Size = new System.Drawing.Size(260, 31);
+            this.cmbColorProfile.Size = new System.Drawing.Size(279, 33);
             this.cmbColorProfile.TabIndex = 30;
             this.cmbColorProfile.SelectedIndexChanged += new System.EventHandler(this.cmbColorProfile_SelectedIndexChanged);
             // 
@@ -1376,10 +1392,10 @@ namespace ImageGlass
             this.lblColorProfile.AutoSize = true;
             this.lblColorProfile.BackColor = System.Drawing.Color.Transparent;
             this.lblColorProfile.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblColorProfile.Location = new System.Drawing.Point(38, 695);
+            this.lblColorProfile.Location = new System.Drawing.Point(41, 786);
             this.lblColorProfile.Margin = new System.Windows.Forms.Padding(1, 4, 1, 4);
             this.lblColorProfile.Name = "lblColorProfile";
-            this.lblColorProfile.Size = new System.Drawing.Size(118, 23);
+            this.lblColorProfile.Size = new System.Drawing.Size(125, 25);
             this.lblColorProfile.TabIndex = 56;
             this.lblColorProfile.Text = "[Color profile:]";
             // 
@@ -1387,10 +1403,10 @@ namespace ImageGlass
             // 
             this.chkShowThumbnailScrollbar.AutoSize = true;
             this.chkShowThumbnailScrollbar.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkShowThumbnailScrollbar.Location = new System.Drawing.Point(44, 1699);
+            this.chkShowThumbnailScrollbar.Location = new System.Drawing.Point(47, 1865);
             this.chkShowThumbnailScrollbar.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowThumbnailScrollbar.Name = "chkShowThumbnailScrollbar";
-            this.chkShowThumbnailScrollbar.Size = new System.Drawing.Size(278, 28);
+            this.chkShowThumbnailScrollbar.Size = new System.Drawing.Size(292, 30);
             this.chkShowThumbnailScrollbar.TabIndex = 42;
             this.chkShowThumbnailScrollbar.Text = "[Show thumbnail bar scrollbar]";
             this.chkShowThumbnailScrollbar.UseVisualStyleBackColor = true;
@@ -1400,10 +1416,10 @@ namespace ImageGlass
             this.cmbMouseWheelAlt.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbMouseWheelAlt.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.cmbMouseWheelAlt.FormattingEnabled = true;
-            this.cmbMouseWheelAlt.Location = new System.Drawing.Point(44, 1098);
+            this.cmbMouseWheelAlt.Location = new System.Drawing.Point(47, 1219);
             this.cmbMouseWheelAlt.Margin = new System.Windows.Forms.Padding(4);
             this.cmbMouseWheelAlt.Name = "cmbMouseWheelAlt";
-            this.cmbMouseWheelAlt.Size = new System.Drawing.Size(260, 31);
+            this.cmbMouseWheelAlt.Size = new System.Drawing.Size(279, 33);
             this.cmbMouseWheelAlt.TabIndex = 36;
             // 
             // cmbMouseWheelShift
@@ -1411,10 +1427,10 @@ namespace ImageGlass
             this.cmbMouseWheelShift.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbMouseWheelShift.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.cmbMouseWheelShift.FormattingEnabled = true;
-            this.cmbMouseWheelShift.Location = new System.Drawing.Point(44, 1025);
+            this.cmbMouseWheelShift.Location = new System.Drawing.Point(47, 1140);
             this.cmbMouseWheelShift.Margin = new System.Windows.Forms.Padding(4);
             this.cmbMouseWheelShift.Name = "cmbMouseWheelShift";
-            this.cmbMouseWheelShift.Size = new System.Drawing.Size(260, 31);
+            this.cmbMouseWheelShift.Size = new System.Drawing.Size(279, 33);
             this.cmbMouseWheelShift.TabIndex = 35;
             // 
             // cmbMouseWheelCtrl
@@ -1422,10 +1438,10 @@ namespace ImageGlass
             this.cmbMouseWheelCtrl.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbMouseWheelCtrl.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.cmbMouseWheelCtrl.FormattingEnabled = true;
-            this.cmbMouseWheelCtrl.Location = new System.Drawing.Point(44, 953);
+            this.cmbMouseWheelCtrl.Location = new System.Drawing.Point(47, 1063);
             this.cmbMouseWheelCtrl.Margin = new System.Windows.Forms.Padding(4);
             this.cmbMouseWheelCtrl.Name = "cmbMouseWheelCtrl";
-            this.cmbMouseWheelCtrl.Size = new System.Drawing.Size(260, 31);
+            this.cmbMouseWheelCtrl.Size = new System.Drawing.Size(279, 33);
             this.cmbMouseWheelCtrl.TabIndex = 34;
             // 
             // cmbMouseWheel
@@ -1433,49 +1449,49 @@ namespace ImageGlass
             this.cmbMouseWheel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbMouseWheel.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.cmbMouseWheel.FormattingEnabled = true;
-            this.cmbMouseWheel.Location = new System.Drawing.Point(44, 879);
+            this.cmbMouseWheel.Location = new System.Drawing.Point(47, 984);
             this.cmbMouseWheel.Margin = new System.Windows.Forms.Padding(4);
             this.cmbMouseWheel.Name = "cmbMouseWheel";
-            this.cmbMouseWheel.Size = new System.Drawing.Size(260, 31);
+            this.cmbMouseWheel.Size = new System.Drawing.Size(279, 33);
             this.cmbMouseWheel.TabIndex = 33;
             // 
             // lblMouseWheelAlt
             // 
             this.lblMouseWheelAlt.AutoSize = true;
-            this.lblMouseWheelAlt.Location = new System.Drawing.Point(38, 1071);
+            this.lblMouseWheelAlt.Location = new System.Drawing.Point(41, 1190);
             this.lblMouseWheelAlt.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblMouseWheelAlt.Name = "lblMouseWheelAlt";
-            this.lblMouseWheelAlt.Size = new System.Drawing.Size(153, 23);
+            this.lblMouseWheelAlt.Size = new System.Drawing.Size(160, 25);
             this.lblMouseWheelAlt.TabIndex = 52;
             this.lblMouseWheelAlt.Text = "Mouse wheel + Alt";
             // 
             // lblMouseWheelShift
             // 
             this.lblMouseWheelShift.AutoSize = true;
-            this.lblMouseWheelShift.Location = new System.Drawing.Point(38, 997);
+            this.lblMouseWheelShift.Location = new System.Drawing.Point(41, 1110);
             this.lblMouseWheelShift.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblMouseWheelShift.Name = "lblMouseWheelShift";
-            this.lblMouseWheelShift.Size = new System.Drawing.Size(166, 23);
+            this.lblMouseWheelShift.Size = new System.Drawing.Size(174, 25);
             this.lblMouseWheelShift.TabIndex = 51;
             this.lblMouseWheelShift.Text = "Mouse wheel + Shift";
             // 
             // lblMouseWheelCtrl
             // 
             this.lblMouseWheelCtrl.AutoSize = true;
-            this.lblMouseWheelCtrl.Location = new System.Drawing.Point(38, 925);
+            this.lblMouseWheelCtrl.Location = new System.Drawing.Point(41, 1033);
             this.lblMouseWheelCtrl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblMouseWheelCtrl.Name = "lblMouseWheelCtrl";
-            this.lblMouseWheelCtrl.Size = new System.Drawing.Size(159, 23);
+            this.lblMouseWheelCtrl.Size = new System.Drawing.Size(165, 25);
             this.lblMouseWheelCtrl.TabIndex = 50;
             this.lblMouseWheelCtrl.Text = "Mouse wheel + Ctrl";
             // 
             // lblMouseWheel
             // 
             this.lblMouseWheel.AutoSize = true;
-            this.lblMouseWheel.Location = new System.Drawing.Point(38, 854);
+            this.lblMouseWheel.Location = new System.Drawing.Point(41, 957);
             this.lblMouseWheel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblMouseWheel.Name = "lblMouseWheel";
-            this.lblMouseWheel.Size = new System.Drawing.Size(110, 23);
+            this.lblMouseWheel.Size = new System.Drawing.Size(116, 25);
             this.lblMouseWheel.TabIndex = 49;
             this.lblMouseWheel.Text = "Mouse wheel";
             // 
@@ -1483,10 +1499,10 @@ namespace ImageGlass
             // 
             this.lblHeadMouseWheelActions.AutoSize = true;
             this.lblHeadMouseWheelActions.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.lblHeadMouseWheelActions.Location = new System.Drawing.Point(22, 818);
+            this.lblHeadMouseWheelActions.Location = new System.Drawing.Point(24, 918);
             this.lblHeadMouseWheelActions.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadMouseWheelActions.Name = "lblHeadMouseWheelActions";
-            this.lblHeadMouseWheelActions.Size = new System.Drawing.Size(175, 23);
+            this.lblHeadMouseWheelActions.Size = new System.Drawing.Size(190, 25);
             this.lblHeadMouseWheelActions.TabIndex = 48;
             this.lblHeadMouseWheelActions.Text = "Mouse wheel actions";
             // 
@@ -1494,30 +1510,30 @@ namespace ImageGlass
             // 
             this.chkShowHiddenImages.AutoSize = true;
             this.chkShowHiddenImages.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkShowHiddenImages.Location = new System.Drawing.Point(44, 116);
+            this.chkShowHiddenImages.Location = new System.Drawing.Point(47, 125);
             this.chkShowHiddenImages.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowHiddenImages.Name = "chkShowHiddenImages";
-            this.chkShowHiddenImages.Size = new System.Drawing.Size(203, 28);
+            this.chkShowHiddenImages.Size = new System.Drawing.Size(216, 30);
             this.chkShowHiddenImages.TabIndex = 18;
             this.chkShowHiddenImages.Text = "Show hidden images";
             this.chkShowHiddenImages.UseVisualStyleBackColor = true;
             // 
             // panel3
             // 
-            this.panel3.Location = new System.Drawing.Point(26, 2203);
+            this.panel3.Location = new System.Drawing.Point(28, 2406);
             this.panel3.Margin = new System.Windows.Forms.Padding(1);
             this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(102, 29);
+            this.panel3.Size = new System.Drawing.Size(110, 31);
             this.panel3.TabIndex = 46;
             // 
             // lblHeadZooming
             // 
             this.lblHeadZooming.AutoSize = true;
             this.lblHeadZooming.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadZooming.Location = new System.Drawing.Point(22, 1384);
+            this.lblHeadZooming.Location = new System.Drawing.Point(24, 1526);
             this.lblHeadZooming.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadZooming.Name = "lblHeadZooming";
-            this.lblHeadZooming.Size = new System.Drawing.Size(82, 23);
+            this.lblHeadZooming.Size = new System.Drawing.Size(88, 25);
             this.lblHeadZooming.TabIndex = 43;
             this.lblHeadZooming.Text = "Zooming";
             // 
@@ -1525,10 +1541,10 @@ namespace ImageGlass
             // 
             this.lblHeadSlideshow.AutoSize = true;
             this.lblHeadSlideshow.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadSlideshow.Location = new System.Drawing.Point(22, 1851);
+            this.lblHeadSlideshow.Location = new System.Drawing.Point(24, 2028);
             this.lblHeadSlideshow.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadSlideshow.Name = "lblHeadSlideshow";
-            this.lblHeadSlideshow.Size = new System.Drawing.Size(91, 23);
+            this.lblHeadSlideshow.Size = new System.Drawing.Size(97, 25);
             this.lblHeadSlideshow.TabIndex = 42;
             this.lblHeadSlideshow.Text = "Slideshow";
             // 
@@ -1536,10 +1552,10 @@ namespace ImageGlass
             // 
             this.lblHeadThumbnailBar.AutoSize = true;
             this.lblHeadThumbnailBar.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadThumbnailBar.Location = new System.Drawing.Point(22, 1637);
+            this.lblHeadThumbnailBar.Location = new System.Drawing.Point(24, 1798);
             this.lblHeadThumbnailBar.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadThumbnailBar.Name = "lblHeadThumbnailBar";
-            this.lblHeadThumbnailBar.Size = new System.Drawing.Size(128, 23);
+            this.lblHeadThumbnailBar.Size = new System.Drawing.Size(136, 25);
             this.lblHeadThumbnailBar.TabIndex = 41;
             this.lblHeadThumbnailBar.Text = "Thumbnail bar";
             // 
@@ -1547,10 +1563,10 @@ namespace ImageGlass
             // 
             this.lblHeadImageLoading.AutoSize = true;
             this.lblHeadImageLoading.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHeadImageLoading.Location = new System.Drawing.Point(22, 16);
+            this.lblHeadImageLoading.Location = new System.Drawing.Point(24, 17);
             this.lblHeadImageLoading.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeadImageLoading.Name = "lblHeadImageLoading";
-            this.lblHeadImageLoading.Size = new System.Drawing.Size(126, 23);
+            this.lblHeadImageLoading.Size = new System.Drawing.Size(134, 25);
             this.lblHeadImageLoading.TabIndex = 40;
             this.lblHeadImageLoading.Text = "Image loading";
             // 
@@ -1558,10 +1574,10 @@ namespace ImageGlass
             // 
             this.chkLoopViewer.AutoSize = true;
             this.chkLoopViewer.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkLoopViewer.Location = new System.Drawing.Point(44, 150);
+            this.chkLoopViewer.Location = new System.Drawing.Point(47, 161);
             this.chkLoopViewer.Margin = new System.Windows.Forms.Padding(1);
             this.chkLoopViewer.Name = "chkLoopViewer";
-            this.chkLoopViewer.Size = new System.Drawing.Size(569, 28);
+            this.chkLoopViewer.Size = new System.Drawing.Size(592, 30);
             this.chkLoopViewer.TabIndex = 19;
             this.chkLoopViewer.Text = "Loop back viewer to the first image when reaching the end of the list";
             this.chkLoopViewer.UseVisualStyleBackColor = true;
@@ -1570,10 +1586,10 @@ namespace ImageGlass
             // 
             this.lblGeneral_ZoomOptimization.AutoSize = true;
             this.lblGeneral_ZoomOptimization.BackColor = System.Drawing.Color.Transparent;
-            this.lblGeneral_ZoomOptimization.Location = new System.Drawing.Point(38, 1418);
+            this.lblGeneral_ZoomOptimization.Location = new System.Drawing.Point(41, 1563);
             this.lblGeneral_ZoomOptimization.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblGeneral_ZoomOptimization.Name = "lblGeneral_ZoomOptimization";
-            this.lblGeneral_ZoomOptimization.Size = new System.Drawing.Size(156, 23);
+            this.lblGeneral_ZoomOptimization.Size = new System.Drawing.Size(165, 25);
             this.lblGeneral_ZoomOptimization.TabIndex = 36;
             this.lblGeneral_ZoomOptimization.Text = "Zoom optimization";
             // 
@@ -1584,20 +1600,20 @@ namespace ImageGlass
             this.cmbZoomOptimization.FormattingEnabled = true;
             this.cmbZoomOptimization.Items.AddRange(new object[] {
             "(loaded from code)"});
-            this.cmbZoomOptimization.Location = new System.Drawing.Point(44, 1446);
+            this.cmbZoomOptimization.Location = new System.Drawing.Point(47, 1593);
             this.cmbZoomOptimization.Margin = new System.Windows.Forms.Padding(1);
             this.cmbZoomOptimization.Name = "cmbZoomOptimization";
-            this.cmbZoomOptimization.Size = new System.Drawing.Size(529, 31);
+            this.cmbZoomOptimization.Size = new System.Drawing.Size(568, 33);
             this.cmbZoomOptimization.TabIndex = 39;
             // 
             // chkThumbnailVertical
             // 
             this.chkThumbnailVertical.AutoSize = true;
             this.chkThumbnailVertical.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkThumbnailVertical.Location = new System.Drawing.Point(44, 1665);
+            this.chkThumbnailVertical.Location = new System.Drawing.Point(47, 1828);
             this.chkThumbnailVertical.Margin = new System.Windows.Forms.Padding(1);
             this.chkThumbnailVertical.Name = "chkThumbnailVertical";
-            this.chkThumbnailVertical.Size = new System.Drawing.Size(257, 28);
+            this.chkThumbnailVertical.Size = new System.Drawing.Size(269, 30);
             this.chkThumbnailVertical.TabIndex = 41;
             this.chkThumbnailVertical.Text = "Thumbnail bar on right side";
             this.chkThumbnailVertical.UseVisualStyleBackColor = true;
@@ -1605,10 +1621,10 @@ namespace ImageGlass
             // lblGeneral_ThumbnailSize
             // 
             this.lblGeneral_ThumbnailSize.AutoSize = true;
-            this.lblGeneral_ThumbnailSize.Location = new System.Drawing.Point(38, 1751);
+            this.lblGeneral_ThumbnailSize.Location = new System.Drawing.Point(41, 1921);
             this.lblGeneral_ThumbnailSize.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblGeneral_ThumbnailSize.Name = "lblGeneral_ThumbnailSize";
-            this.lblGeneral_ThumbnailSize.Size = new System.Drawing.Size(248, 23);
+            this.lblGeneral_ThumbnailSize.Size = new System.Drawing.Size(257, 25);
             this.lblGeneral_ThumbnailSize.TabIndex = 33;
             this.lblGeneral_ThumbnailSize.Text = "Thumbnail dimension (in pixel):";
             // 
@@ -1626,20 +1642,20 @@ namespace ImageGlass
             "256",
             "512",
             "1024"});
-            this.cmbThumbnailDimension.Location = new System.Drawing.Point(44, 1778);
+            this.cmbThumbnailDimension.Location = new System.Drawing.Point(47, 1950);
             this.cmbThumbnailDimension.Margin = new System.Windows.Forms.Padding(1);
             this.cmbThumbnailDimension.Name = "cmbThumbnailDimension";
-            this.cmbThumbnailDimension.Size = new System.Drawing.Size(260, 31);
+            this.cmbThumbnailDimension.Size = new System.Drawing.Size(279, 33);
             this.cmbThumbnailDimension.TabIndex = 43;
             // 
             // chkUseFileExplorerSortOrder
             // 
             this.chkUseFileExplorerSortOrder.AutoSize = true;
             this.chkUseFileExplorerSortOrder.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkUseFileExplorerSortOrder.Location = new System.Drawing.Point(44, 464);
+            this.chkUseFileExplorerSortOrder.Location = new System.Drawing.Point(47, 538);
             this.chkUseFileExplorerSortOrder.Margin = new System.Windows.Forms.Padding(1);
             this.chkUseFileExplorerSortOrder.Name = "chkUseFileExplorerSortOrder";
-            this.chkUseFileExplorerSortOrder.Size = new System.Drawing.Size(414, 28);
+            this.chkUseFileExplorerSortOrder.Size = new System.Drawing.Size(438, 30);
             this.chkUseFileExplorerSortOrder.TabIndex = 27;
             this.chkUseFileExplorerSortOrder.Text = "[Use Windows File Explorer sort order if possible]";
             this.chkUseFileExplorerSortOrder.UseVisualStyleBackColor = true;
@@ -1648,10 +1664,10 @@ namespace ImageGlass
             // 
             this.chkLoopSlideshow.AutoSize = true;
             this.chkLoopSlideshow.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkLoopSlideshow.Location = new System.Drawing.Point(44, 1881);
+            this.chkLoopSlideshow.Location = new System.Drawing.Point(47, 2060);
             this.chkLoopSlideshow.Margin = new System.Windows.Forms.Padding(1);
             this.chkLoopSlideshow.Name = "chkLoopSlideshow";
-            this.chkLoopSlideshow.Size = new System.Drawing.Size(604, 28);
+            this.chkLoopSlideshow.Size = new System.Drawing.Size(630, 30);
             this.chkLoopSlideshow.TabIndex = 44;
             this.chkLoopSlideshow.Text = "[Loop back slideshow to the first image when reaching the end of the list]";
             this.chkLoopSlideshow.UseVisualStyleBackColor = true;
@@ -1659,10 +1675,10 @@ namespace ImageGlass
             // lblImageLoadingOrder
             // 
             this.lblImageLoadingOrder.AutoSize = true;
-            this.lblImageLoadingOrder.Location = new System.Drawing.Point(38, 399);
+            this.lblImageLoadingOrder.Location = new System.Drawing.Point(41, 468);
             this.lblImageLoadingOrder.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblImageLoadingOrder.Name = "lblImageLoadingOrder";
-            this.lblImageLoadingOrder.Size = new System.Drawing.Size(170, 23);
+            this.lblImageLoadingOrder.Size = new System.Drawing.Size(179, 25);
             this.lblImageLoadingOrder.TabIndex = 28;
             this.lblImageLoadingOrder.Text = "Image loading order:";
             // 
@@ -1679,19 +1695,19 @@ namespace ImageGlass
             "Last write time",
             "Extension",
             "Random"});
-            this.cmbImageOrder.Location = new System.Drawing.Point(44, 425);
+            this.cmbImageOrder.Location = new System.Drawing.Point(47, 496);
             this.cmbImageOrder.Margin = new System.Windows.Forms.Padding(1);
             this.cmbImageOrder.Name = "cmbImageOrder";
-            this.cmbImageOrder.Size = new System.Drawing.Size(260, 31);
+            this.cmbImageOrder.Size = new System.Drawing.Size(279, 33);
             this.cmbImageOrder.TabIndex = 25;
             // 
             // lblSlideshowInterval
             // 
             this.lblSlideshowInterval.AutoSize = true;
-            this.lblSlideshowInterval.Location = new System.Drawing.Point(60, 1986);
+            this.lblSlideshowInterval.Location = new System.Drawing.Point(64, 2173);
             this.lblSlideshowInterval.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblSlideshowInterval.Name = "lblSlideshowInterval";
-            this.lblSlideshowInterval.Size = new System.Drawing.Size(205, 23);
+            this.lblSlideshowInterval.Size = new System.Drawing.Size(217, 25);
             this.lblSlideshowInterval.TabIndex = 24;
             this.lblSlideshowInterval.Text = "[Slideshow interval: 00:03]";
             // 
@@ -1699,10 +1715,10 @@ namespace ImageGlass
             // 
             this.chkFindChildFolder.AutoSize = true;
             this.chkFindChildFolder.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkFindChildFolder.Location = new System.Drawing.Point(44, 46);
+            this.chkFindChildFolder.Location = new System.Drawing.Point(47, 49);
             this.chkFindChildFolder.Margin = new System.Windows.Forms.Padding(1);
             this.chkFindChildFolder.Name = "chkFindChildFolder";
-            this.chkFindChildFolder.Size = new System.Drawing.Size(245, 28);
+            this.chkFindChildFolder.Size = new System.Drawing.Size(259, 30);
             this.chkFindChildFolder.TabIndex = 16;
             this.chkFindChildFolder.Text = "Find images in child folder";
             this.chkFindChildFolder.UseVisualStyleBackColor = true;
@@ -1711,10 +1727,10 @@ namespace ImageGlass
             // 
             this.tabEdit.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(198)))), ((int)(((byte)(203)))), ((int)(((byte)(204)))));
             this.tabEdit.Controls.Add(this.tableEdit);
-            this.tabEdit.Location = new System.Drawing.Point(4, 69);
+            this.tabEdit.Location = new System.Drawing.Point(4, 73);
             this.tabEdit.Margin = new System.Windows.Forms.Padding(0);
             this.tabEdit.Name = "tabEdit";
-            this.tabEdit.Size = new System.Drawing.Size(744, 596);
+            this.tabEdit.Size = new System.Drawing.Size(801, 642);
             this.tabEdit.TabIndex = 7;
             this.tabEdit.Text = "Edit";
             // 
@@ -1730,8 +1746,8 @@ namespace ImageGlass
             this.tableEdit.Name = "tableEdit";
             this.tableEdit.RowCount = 2;
             this.tableEdit.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableEdit.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 71F));
-            this.tableEdit.Size = new System.Drawing.Size(744, 596);
+            this.tableEdit.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 76F));
+            this.tableEdit.Size = new System.Drawing.Size(801, 642);
             this.tableEdit.TabIndex = 62;
             // 
             // panel6
@@ -1749,7 +1765,7 @@ namespace ImageGlass
             this.panel6.Location = new System.Drawing.Point(0, 0);
             this.panel6.Margin = new System.Windows.Forms.Padding(0);
             this.panel6.Name = "panel6";
-            this.panel6.Size = new System.Drawing.Size(744, 525);
+            this.panel6.Size = new System.Drawing.Size(801, 566);
             this.panel6.TabIndex = 60;
             // 
             // cmbAfterEditingApp
@@ -1761,26 +1777,26 @@ namespace ImageGlass
             "AAA",
             "BBB",
             "CCC"});
-            this.cmbAfterEditingApp.Location = new System.Drawing.Point(22, 127);
+            this.cmbAfterEditingApp.Location = new System.Drawing.Point(24, 136);
             this.cmbAfterEditingApp.Margin = new System.Windows.Forms.Padding(1);
             this.cmbAfterEditingApp.Name = "cmbAfterEditingApp";
-            this.cmbAfterEditingApp.Size = new System.Drawing.Size(260, 31);
+            this.cmbAfterEditingApp.Size = new System.Drawing.Size(279, 33);
             this.cmbAfterEditingApp.TabIndex = 7;
             // 
             // lblAfterEditingApp
             // 
             this.lblAfterEditingApp.AutoSize = true;
-            this.lblAfterEditingApp.Location = new System.Drawing.Point(18, 99);
+            this.lblAfterEditingApp.Location = new System.Drawing.Point(19, 106);
             this.lblAfterEditingApp.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblAfterEditingApp.Name = "lblAfterEditingApp";
-            this.lblAfterEditingApp.Size = new System.Drawing.Size(221, 23);
+            this.lblAfterEditingApp.Size = new System.Drawing.Size(232, 25);
             this.lblAfterEditingApp.TabIndex = 63;
             this.lblAfterEditingApp.Text = "[After opening editing app:]";
             // 
             // numImageQuality
             // 
             this.numImageQuality.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
-            this.numImageQuality.Location = new System.Drawing.Point(370, 127);
+            this.numImageQuality.Location = new System.Drawing.Point(398, 136);
             this.numImageQuality.Margin = new System.Windows.Forms.Padding(4);
             this.numImageQuality.Minimum = new decimal(new int[] {
             1,
@@ -1788,7 +1804,7 @@ namespace ImageGlass
             0,
             0});
             this.numImageQuality.Name = "numImageQuality";
-            this.numImageQuality.Size = new System.Drawing.Size(107, 30);
+            this.numImageQuality.Size = new System.Drawing.Size(115, 31);
             this.numImageQuality.TabIndex = 8;
             this.numImageQuality.Value = new decimal(new int[] {
             1,
@@ -1799,10 +1815,10 @@ namespace ImageGlass
             // lblImageQuality
             // 
             this.lblImageQuality.AutoSize = true;
-            this.lblImageQuality.Location = new System.Drawing.Point(367, 99);
+            this.lblImageQuality.Location = new System.Drawing.Point(394, 106);
             this.lblImageQuality.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblImageQuality.Name = "lblImageQuality";
-            this.lblImageQuality.Size = new System.Drawing.Size(128, 23);
+            this.lblImageQuality.Size = new System.Drawing.Size(134, 25);
             this.lblImageQuality.TabIndex = 61;
             this.lblImageQuality.Text = "[Image quality:]";
             // 
@@ -1810,10 +1826,10 @@ namespace ImageGlass
             // 
             this.chkSaveOnRotate.AutoSize = true;
             this.chkSaveOnRotate.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkSaveOnRotate.Location = new System.Drawing.Point(22, 21);
+            this.chkSaveOnRotate.Location = new System.Drawing.Point(24, 23);
             this.chkSaveOnRotate.Margin = new System.Windows.Forms.Padding(1);
             this.chkSaveOnRotate.Name = "chkSaveOnRotate";
-            this.chkSaveOnRotate.Size = new System.Drawing.Size(330, 28);
+            this.chkSaveOnRotate.Size = new System.Drawing.Size(345, 30);
             this.chkSaveOnRotate.TabIndex = 5;
             this.chkSaveOnRotate.Text = "Save the viewing image after rotating";
             this.chkSaveOnRotate.UseVisualStyleBackColor = true;
@@ -1821,10 +1837,10 @@ namespace ImageGlass
             // lblSelectAppForEdit
             // 
             this.lblSelectAppForEdit.AutoSize = true;
-            this.lblSelectAppForEdit.Location = new System.Drawing.Point(18, 180);
+            this.lblSelectAppForEdit.Location = new System.Drawing.Point(19, 193);
             this.lblSelectAppForEdit.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblSelectAppForEdit.Name = "lblSelectAppForEdit";
-            this.lblSelectAppForEdit.Size = new System.Drawing.Size(284, 23);
+            this.lblSelectAppForEdit.Size = new System.Drawing.Size(296, 25);
             this.lblSelectAppForEdit.TabIndex = 59;
             this.lblSelectAppForEdit.Text = "Select application for image editing:";
             // 
@@ -1849,12 +1865,12 @@ namespace ImageGlass
             listViewItem1,
             listViewItem2,
             listViewItem3});
-            this.lvImageEditing.Location = new System.Drawing.Point(22, 207);
+            this.lvImageEditing.Location = new System.Drawing.Point(24, 222);
             this.lvImageEditing.Margin = new System.Windows.Forms.Padding(4);
             this.lvImageEditing.Name = "lvImageEditing";
             this.lvImageEditing.RightToLeftLayout = true;
             this.lvImageEditing.ShowItemToolTips = true;
-            this.lvImageEditing.Size = new System.Drawing.Size(706, 270);
+            this.lvImageEditing.Size = new System.Drawing.Size(759, 292);
             this.lvImageEditing.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.lvImageEditing.TabIndex = 9;
             this.lvImageEditing.UseCompatibleStateImageBehavior = false;
@@ -1886,10 +1902,10 @@ namespace ImageGlass
             // 
             this.chkSaveModifyDate.AutoSize = true;
             this.chkSaveModifyDate.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkSaveModifyDate.Location = new System.Drawing.Point(22, 55);
+            this.chkSaveModifyDate.Location = new System.Drawing.Point(24, 59);
             this.chkSaveModifyDate.Margin = new System.Windows.Forms.Padding(1);
             this.chkSaveModifyDate.Name = "chkSaveModifyDate";
-            this.chkSaveModifyDate.Size = new System.Drawing.Size(341, 28);
+            this.chkSaveModifyDate.Size = new System.Drawing.Size(357, 30);
             this.chkSaveModifyDate.TabIndex = 6;
             this.chkSaveModifyDate.Text = "Preserve the modification date on save";
             this.chkSaveModifyDate.UseVisualStyleBackColor = true;
@@ -1901,10 +1917,10 @@ namespace ImageGlass
             this.panel7.Controls.Add(this.btnEditResetExt);
             this.panel7.Controls.Add(this.btnEditEditAllExt);
             this.panel7.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel7.Location = new System.Drawing.Point(0, 525);
+            this.panel7.Location = new System.Drawing.Point(0, 566);
             this.panel7.Margin = new System.Windows.Forms.Padding(0);
             this.panel7.Name = "panel7";
-            this.panel7.Size = new System.Drawing.Size(744, 71);
+            this.panel7.Size = new System.Drawing.Size(801, 76);
             this.panel7.TabIndex = 61;
             // 
             // btnEditEditExt
@@ -1912,10 +1928,10 @@ namespace ImageGlass
             this.btnEditEditExt.AutoSize = true;
             this.btnEditEditExt.Enabled = false;
             this.btnEditEditExt.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnEditEditExt.Location = new System.Drawing.Point(22, 4);
+            this.btnEditEditExt.Location = new System.Drawing.Point(24, 4);
             this.btnEditEditExt.Margin = new System.Windows.Forms.Padding(4);
             this.btnEditEditExt.Name = "btnEditEditExt";
-            this.btnEditEditExt.Size = new System.Drawing.Size(183, 44);
+            this.btnEditEditExt.Size = new System.Drawing.Size(197, 47);
             this.btnEditEditExt.TabIndex = 10;
             this.btnEditEditExt.Text = "Edit";
             this.btnEditEditExt.UseVisualStyleBackColor = true;
@@ -1925,10 +1941,10 @@ namespace ImageGlass
             // 
             this.btnEditResetExt.AutoSize = true;
             this.btnEditResetExt.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnEditResetExt.Location = new System.Drawing.Point(465, 4);
+            this.btnEditResetExt.Location = new System.Drawing.Point(500, 4);
             this.btnEditResetExt.Margin = new System.Windows.Forms.Padding(4);
             this.btnEditResetExt.Name = "btnEditResetExt";
-            this.btnEditResetExt.Size = new System.Drawing.Size(246, 44);
+            this.btnEditResetExt.Size = new System.Drawing.Size(264, 47);
             this.btnEditResetExt.TabIndex = 12;
             this.btnEditResetExt.Text = "Reset to default";
             this.btnEditResetExt.UseVisualStyleBackColor = true;
@@ -1938,10 +1954,10 @@ namespace ImageGlass
             // 
             this.btnEditEditAllExt.AutoSize = true;
             this.btnEditEditAllExt.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnEditEditAllExt.Location = new System.Drawing.Point(211, 4);
+            this.btnEditEditAllExt.Location = new System.Drawing.Point(227, 4);
             this.btnEditEditAllExt.Margin = new System.Windows.Forms.Padding(4);
             this.btnEditEditAllExt.Name = "btnEditEditAllExt";
-            this.btnEditEditAllExt.Size = new System.Drawing.Size(247, 44);
+            this.btnEditEditAllExt.Size = new System.Drawing.Size(265, 47);
             this.btnEditEditAllExt.TabIndex = 11;
             this.btnEditEditAllExt.Text = "Edit all extensions";
             this.btnEditEditAllExt.UseVisualStyleBackColor = true;
@@ -1951,10 +1967,10 @@ namespace ImageGlass
             // 
             this.tabFileTypeAssoc.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(198)))), ((int)(((byte)(203)))), ((int)(((byte)(204)))));
             this.tabFileTypeAssoc.Controls.Add(this.tableFileAssoc);
-            this.tabFileTypeAssoc.Location = new System.Drawing.Point(4, 69);
+            this.tabFileTypeAssoc.Location = new System.Drawing.Point(4, 73);
             this.tabFileTypeAssoc.Margin = new System.Windows.Forms.Padding(0);
             this.tabFileTypeAssoc.Name = "tabFileTypeAssoc";
-            this.tabFileTypeAssoc.Size = new System.Drawing.Size(744, 596);
+            this.tabFileTypeAssoc.Size = new System.Drawing.Size(801, 642);
             this.tabFileTypeAssoc.TabIndex = 1;
             this.tabFileTypeAssoc.Text = "file association";
             // 
@@ -1970,8 +1986,8 @@ namespace ImageGlass
             this.tableFileAssoc.Name = "tableFileAssoc";
             this.tableFileAssoc.RowCount = 2;
             this.tableFileAssoc.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableFileAssoc.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 118F));
-            this.tableFileAssoc.Size = new System.Drawing.Size(744, 596);
+            this.tableFileAssoc.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 127F));
+            this.tableFileAssoc.Size = new System.Drawing.Size(801, 642);
             this.tableFileAssoc.TabIndex = 44;
             // 
             // panel2
@@ -1983,10 +1999,10 @@ namespace ImageGlass
             this.panel2.Controls.Add(this.btnAddNewExt);
             this.panel2.Controls.Add(this.btnDeleteExt);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel2.Location = new System.Drawing.Point(0, 478);
+            this.panel2.Location = new System.Drawing.Point(0, 515);
             this.panel2.Margin = new System.Windows.Forms.Padding(0);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(744, 118);
+            this.panel2.Size = new System.Drawing.Size(801, 127);
             this.panel2.TabIndex = 35;
             // 
             // btnUnregisterExt
@@ -1994,10 +2010,10 @@ namespace ImageGlass
             this.btnUnregisterExt.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnUnregisterExt.AutoSize = true;
             this.btnUnregisterExt.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnUnregisterExt.Location = new System.Drawing.Point(346, 51);
+            this.btnUnregisterExt.Location = new System.Drawing.Point(373, 55);
             this.btnUnregisterExt.Margin = new System.Windows.Forms.Padding(4);
             this.btnUnregisterExt.Name = "btnUnregisterExt";
-            this.btnUnregisterExt.Size = new System.Drawing.Size(379, 44);
+            this.btnUnregisterExt.Size = new System.Drawing.Size(407, 47);
             this.btnUnregisterExt.TabIndex = 47;
             this.btnUnregisterExt.Text = "[Unregister extensions]";
             this.btnUnregisterExt.UseVisualStyleBackColor = true;
@@ -2008,10 +2024,10 @@ namespace ImageGlass
             this.btnRegisterExt.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnRegisterExt.AutoSize = true;
             this.btnRegisterExt.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnRegisterExt.Location = new System.Drawing.Point(346, 4);
+            this.btnRegisterExt.Location = new System.Drawing.Point(373, 4);
             this.btnRegisterExt.Margin = new System.Windows.Forms.Padding(4);
             this.btnRegisterExt.Name = "btnRegisterExt";
-            this.btnRegisterExt.Size = new System.Drawing.Size(379, 44);
+            this.btnRegisterExt.Size = new System.Drawing.Size(407, 47);
             this.btnRegisterExt.TabIndex = 46;
             this.btnRegisterExt.Text = "[Set as Default photo viewer...]";
             this.btnRegisterExt.UseVisualStyleBackColor = true;
@@ -2021,10 +2037,10 @@ namespace ImageGlass
             // 
             this.btnResetExt.AutoSize = true;
             this.btnResetExt.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnResetExt.Location = new System.Drawing.Point(28, 51);
+            this.btnResetExt.Location = new System.Drawing.Point(30, 55);
             this.btnResetExt.Margin = new System.Windows.Forms.Padding(4);
             this.btnResetExt.Name = "btnResetExt";
-            this.btnResetExt.Size = new System.Drawing.Size(302, 44);
+            this.btnResetExt.Size = new System.Drawing.Size(325, 47);
             this.btnResetExt.TabIndex = 45;
             this.btnResetExt.Text = "Reset to default";
             this.btnResetExt.UseVisualStyleBackColor = true;
@@ -2034,10 +2050,10 @@ namespace ImageGlass
             // 
             this.btnAddNewExt.AutoSize = true;
             this.btnAddNewExt.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnAddNewExt.Location = new System.Drawing.Point(28, 4);
+            this.btnAddNewExt.Location = new System.Drawing.Point(30, 4);
             this.btnAddNewExt.Margin = new System.Windows.Forms.Padding(4);
             this.btnAddNewExt.Name = "btnAddNewExt";
-            this.btnAddNewExt.Size = new System.Drawing.Size(150, 44);
+            this.btnAddNewExt.Size = new System.Drawing.Size(161, 47);
             this.btnAddNewExt.TabIndex = 43;
             this.btnAddNewExt.Text = "Add";
             this.btnAddNewExt.UseVisualStyleBackColor = true;
@@ -2048,10 +2064,10 @@ namespace ImageGlass
             this.btnDeleteExt.AutoSize = true;
             this.btnDeleteExt.Enabled = false;
             this.btnDeleteExt.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnDeleteExt.Location = new System.Drawing.Point(180, 4);
+            this.btnDeleteExt.Location = new System.Drawing.Point(193, 4);
             this.btnDeleteExt.Margin = new System.Windows.Forms.Padding(4);
             this.btnDeleteExt.Name = "btnDeleteExt";
-            this.btnDeleteExt.Size = new System.Drawing.Size(150, 44);
+            this.btnDeleteExt.Size = new System.Drawing.Size(161, 47);
             this.btnDeleteExt.TabIndex = 44;
             this.btnDeleteExt.Text = "Delete";
             this.btnDeleteExt.UseVisualStyleBackColor = true;
@@ -2067,16 +2083,16 @@ namespace ImageGlass
             this.panel8.Location = new System.Drawing.Point(0, 0);
             this.panel8.Margin = new System.Windows.Forms.Padding(0);
             this.panel8.Name = "panel8";
-            this.panel8.Size = new System.Drawing.Size(744, 478);
+            this.panel8.Size = new System.Drawing.Size(801, 515);
             this.panel8.TabIndex = 43;
             // 
             // lblSupportedExtension
             // 
             this.lblSupportedExtension.AutoSize = true;
-            this.lblSupportedExtension.Location = new System.Drawing.Point(22, 21);
+            this.lblSupportedExtension.Location = new System.Drawing.Point(24, 23);
             this.lblSupportedExtension.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblSupportedExtension.Name = "lblSupportedExtension";
-            this.lblSupportedExtension.Size = new System.Drawing.Size(179, 23);
+            this.lblSupportedExtension.Size = new System.Drawing.Size(189, 25);
             this.lblSupportedExtension.TabIndex = 21;
             this.lblSupportedExtension.Text = "Supported extensions:";
             // 
@@ -2092,11 +2108,11 @@ namespace ImageGlass
             this.lvExtension.FullRowSelect = true;
             this.lvExtension.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
             this.lvExtension.HideSelection = false;
-            this.lvExtension.Location = new System.Drawing.Point(28, 46);
+            this.lvExtension.Location = new System.Drawing.Point(30, 49);
             this.lvExtension.Margin = new System.Windows.Forms.Padding(4);
             this.lvExtension.Name = "lvExtension";
             this.lvExtension.ShowItemToolTips = true;
-            this.lvExtension.Size = new System.Drawing.Size(696, 381);
+            this.lvExtension.Size = new System.Drawing.Size(749, 410);
             this.lvExtension.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.lvExtension.TabIndex = 42;
             this.lvExtension.TileSize = new System.Drawing.Size(100, 30);
@@ -2121,10 +2137,10 @@ namespace ImageGlass
             this.lnkOpenFileAssoc.BackColor = System.Drawing.Color.Transparent;
             this.lnkOpenFileAssoc.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkOpenFileAssoc.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkOpenFileAssoc.Location = new System.Drawing.Point(357, 16);
+            this.lnkOpenFileAssoc.Location = new System.Drawing.Point(385, 17);
             this.lnkOpenFileAssoc.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkOpenFileAssoc.Name = "lnkOpenFileAssoc";
-            this.lnkOpenFileAssoc.Size = new System.Drawing.Size(364, 32);
+            this.lnkOpenFileAssoc.Size = new System.Drawing.Size(391, 34);
             this.lnkOpenFileAssoc.TabIndex = 41;
             this.lnkOpenFileAssoc.TabStop = true;
             this.lnkOpenFileAssoc.Text = "Open File Associations";
@@ -2137,10 +2153,10 @@ namespace ImageGlass
             this.tabToolbar.AutoScroll = true;
             this.tabToolbar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(198)))), ((int)(((byte)(203)))), ((int)(((byte)(204)))));
             this.tabToolbar.Controls.Add(this.tableLayoutPanel1);
-            this.tabToolbar.Location = new System.Drawing.Point(4, 69);
+            this.tabToolbar.Location = new System.Drawing.Point(4, 73);
             this.tabToolbar.Margin = new System.Windows.Forms.Padding(0);
             this.tabToolbar.Name = "tabToolbar";
-            this.tabToolbar.Size = new System.Drawing.Size(744, 596);
+            this.tabToolbar.Size = new System.Drawing.Size(801, 642);
             this.tabToolbar.TabIndex = 4;
             this.tabToolbar.Text = "toolbar";
             // 
@@ -2156,9 +2172,9 @@ namespace ImageGlass
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 169F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 182F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(744, 596);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(801, 642);
             this.tableLayoutPanel1.TabIndex = 50;
             // 
             // panel9
@@ -2173,23 +2189,23 @@ namespace ImageGlass
             this.panel9.Location = new System.Drawing.Point(0, 4);
             this.panel9.Margin = new System.Windows.Forms.Padding(0, 4, 4, 4);
             this.panel9.Name = "panel9";
-            this.panel9.Size = new System.Drawing.Size(740, 161);
+            this.panel9.Size = new System.Drawing.Size(797, 174);
             this.panel9.TabIndex = 49;
             // 
             // lblToolbarIconHeight
             // 
             this.lblToolbarIconHeight.AutoSize = true;
-            this.lblToolbarIconHeight.Location = new System.Drawing.Point(370, 21);
+            this.lblToolbarIconHeight.Location = new System.Drawing.Point(398, 23);
             this.lblToolbarIconHeight.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblToolbarIconHeight.Name = "lblToolbarIconHeight";
-            this.lblToolbarIconHeight.Size = new System.Drawing.Size(150, 23);
+            this.lblToolbarIconHeight.Size = new System.Drawing.Size(157, 25);
             this.lblToolbarIconHeight.TabIndex = 51;
             this.lblToolbarIconHeight.Text = "[Toolbar icon size:]";
             // 
             // numToolbarIconHeight
             // 
             this.numToolbarIconHeight.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
-            this.numToolbarIconHeight.Location = new System.Drawing.Point(375, 46);
+            this.numToolbarIconHeight.Location = new System.Drawing.Point(403, 49);
             this.numToolbarIconHeight.Margin = new System.Windows.Forms.Padding(1);
             this.numToolbarIconHeight.Maximum = new decimal(new int[] {
             200,
@@ -2202,7 +2218,7 @@ namespace ImageGlass
             0,
             0});
             this.numToolbarIconHeight.Name = "numToolbarIconHeight";
-            this.numToolbarIconHeight.Size = new System.Drawing.Size(102, 30);
+            this.numToolbarIconHeight.Size = new System.Drawing.Size(110, 31);
             this.numToolbarIconHeight.TabIndex = 48;
             this.numToolbarIconHeight.Value = new decimal(new int[] {
             20,
@@ -2214,10 +2230,10 @@ namespace ImageGlass
             // 
             this.chkHideTooltips.AutoSize = true;
             this.chkHideTooltips.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkHideTooltips.Location = new System.Drawing.Point(27, 118);
+            this.chkHideTooltips.Location = new System.Drawing.Point(29, 127);
             this.chkHideTooltips.Margin = new System.Windows.Forms.Padding(1);
             this.chkHideTooltips.Name = "chkHideTooltips";
-            this.chkHideTooltips.Size = new System.Drawing.Size(212, 28);
+            this.chkHideTooltips.Size = new System.Drawing.Size(226, 30);
             this.chkHideTooltips.TabIndex = 50;
             this.chkHideTooltips.Text = "[Hide toolbar tooltips]";
             this.chkHideTooltips.UseVisualStyleBackColor = true;
@@ -2227,10 +2243,10 @@ namespace ImageGlass
             this.lblToolbarPosition.AutoSize = true;
             this.lblToolbarPosition.BackColor = System.Drawing.Color.Transparent;
             this.lblToolbarPosition.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblToolbarPosition.Location = new System.Drawing.Point(22, 21);
+            this.lblToolbarPosition.Location = new System.Drawing.Point(24, 23);
             this.lblToolbarPosition.Margin = new System.Windows.Forms.Padding(1, 4, 1, 4);
             this.lblToolbarPosition.Name = "lblToolbarPosition";
-            this.lblToolbarPosition.Size = new System.Drawing.Size(146, 23);
+            this.lblToolbarPosition.Size = new System.Drawing.Size(155, 25);
             this.lblToolbarPosition.TabIndex = 44;
             this.lblToolbarPosition.Text = "[Toolbar position:]";
             // 
@@ -2238,10 +2254,10 @@ namespace ImageGlass
             // 
             this.chkHorzCenterToolbarBtns.AutoSize = true;
             this.chkHorzCenterToolbarBtns.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkHorzCenterToolbarBtns.Location = new System.Drawing.Point(28, 84);
+            this.chkHorzCenterToolbarBtns.Location = new System.Drawing.Point(30, 90);
             this.chkHorzCenterToolbarBtns.Margin = new System.Windows.Forms.Padding(1);
             this.chkHorzCenterToolbarBtns.Name = "chkHorzCenterToolbarBtns";
-            this.chkHorzCenterToolbarBtns.Size = new System.Drawing.Size(406, 28);
+            this.chkHorzCenterToolbarBtns.Size = new System.Drawing.Size(424, 30);
             this.chkHorzCenterToolbarBtns.TabIndex = 49;
             this.chkHorzCenterToolbarBtns.Text = "[Center toolbar buttons horizontally in window]";
             this.chkHorzCenterToolbarBtns.UseVisualStyleBackColor = true;
@@ -2251,10 +2267,10 @@ namespace ImageGlass
             this.cmbToolbarPosition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbToolbarPosition.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.cmbToolbarPosition.FormattingEnabled = true;
-            this.cmbToolbarPosition.Location = new System.Drawing.Point(28, 46);
+            this.cmbToolbarPosition.Location = new System.Drawing.Point(30, 49);
             this.cmbToolbarPosition.Margin = new System.Windows.Forms.Padding(1);
             this.cmbToolbarPosition.Name = "cmbToolbarPosition";
-            this.cmbToolbarPosition.Size = new System.Drawing.Size(260, 31);
+            this.cmbToolbarPosition.Size = new System.Drawing.Size(279, 33);
             this.cmbToolbarPosition.TabIndex = 47;
             // 
             // panel5
@@ -2268,10 +2284,10 @@ namespace ImageGlass
             this.panel5.Controls.Add(this.lvUsedButtons);
             this.panel5.Controls.Add(this.btnMoveDown);
             this.panel5.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel5.Location = new System.Drawing.Point(0, 173);
+            this.panel5.Location = new System.Drawing.Point(0, 186);
             this.panel5.Margin = new System.Windows.Forms.Padding(0, 4, 4, 4);
             this.panel5.Name = "panel5";
-            this.panel5.Size = new System.Drawing.Size(740, 419);
+            this.panel5.Size = new System.Drawing.Size(797, 452);
             this.panel5.TabIndex = 48;
             // 
             // lblAvailBtns
@@ -2279,10 +2295,10 @@ namespace ImageGlass
             this.lblAvailBtns.AutoSize = true;
             this.lblAvailBtns.BackColor = System.Drawing.Color.Transparent;
             this.lblAvailBtns.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblAvailBtns.Location = new System.Drawing.Point(22, 7);
+            this.lblAvailBtns.Location = new System.Drawing.Point(24, 8);
             this.lblAvailBtns.Margin = new System.Windows.Forms.Padding(1, 4, 1, 4);
             this.lblAvailBtns.Name = "lblAvailBtns";
-            this.lblAvailBtns.Size = new System.Drawing.Size(156, 23);
+            this.lblAvailBtns.Size = new System.Drawing.Size(163, 25);
             this.lblAvailBtns.TabIndex = 3;
             this.lblAvailBtns.Text = "[Available Buttons:]";
             // 
@@ -2291,10 +2307,10 @@ namespace ImageGlass
             this.btnMoveRight.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.btnMoveRight.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.btnMoveRight.Font = new System.Drawing.Font("Arial", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnMoveRight.Location = new System.Drawing.Point(317, 233);
+            this.btnMoveRight.Location = new System.Drawing.Point(341, 251);
             this.btnMoveRight.Margin = new System.Windows.Forms.Padding(4);
             this.btnMoveRight.Name = "btnMoveRight";
-            this.btnMoveRight.Size = new System.Drawing.Size(46, 46);
+            this.btnMoveRight.Size = new System.Drawing.Size(49, 49);
             this.btnMoveRight.TabIndex = 53;
             this.btnMoveRight.Text = "►";
             this.btnMoveRight.UseVisualStyleBackColor = true;
@@ -2305,10 +2321,10 @@ namespace ImageGlass
             this.btnMoveLeft.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.btnMoveLeft.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.btnMoveLeft.Font = new System.Drawing.Font("Arial", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnMoveLeft.Location = new System.Drawing.Point(317, 170);
+            this.btnMoveLeft.Location = new System.Drawing.Point(341, 184);
             this.btnMoveLeft.Margin = new System.Windows.Forms.Padding(4);
             this.btnMoveLeft.Name = "btnMoveLeft";
-            this.btnMoveLeft.Size = new System.Drawing.Size(46, 46);
+            this.btnMoveLeft.Size = new System.Drawing.Size(49, 49);
             this.btnMoveLeft.TabIndex = 52;
             this.btnMoveLeft.Text = "◄";
             this.btnMoveLeft.UseVisualStyleBackColor = true;
@@ -2319,10 +2335,10 @@ namespace ImageGlass
             this.btnMoveUp.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.btnMoveUp.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.btnMoveUp.Font = new System.Drawing.Font("Arial", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnMoveUp.Location = new System.Drawing.Point(669, 170);
+            this.btnMoveUp.Location = new System.Drawing.Point(719, 184);
             this.btnMoveUp.Margin = new System.Windows.Forms.Padding(4);
             this.btnMoveUp.Name = "btnMoveUp";
-            this.btnMoveUp.Size = new System.Drawing.Size(46, 46);
+            this.btnMoveUp.Size = new System.Drawing.Size(49, 49);
             this.btnMoveUp.TabIndex = 55;
             this.btnMoveUp.Text = "▲";
             this.btnMoveUp.UseVisualStyleBackColor = true;
@@ -2338,12 +2354,12 @@ namespace ImageGlass
             this.lvAvailButtons.FullRowSelect = true;
             this.lvAvailButtons.GridLines = true;
             this.lvAvailButtons.HideSelection = false;
-            this.lvAvailButtons.Location = new System.Drawing.Point(28, 40);
+            this.lvAvailButtons.Location = new System.Drawing.Point(30, 43);
             this.lvAvailButtons.Margin = new System.Windows.Forms.Padding(4);
             this.lvAvailButtons.Name = "lvAvailButtons";
             this.lvAvailButtons.ShowGroups = false;
             this.lvAvailButtons.ShowItemToolTips = true;
-            this.lvAvailButtons.Size = new System.Drawing.Size(275, 330);
+            this.lvAvailButtons.Size = new System.Drawing.Size(296, 357);
             this.lvAvailButtons.TabIndex = 51;
             this.lvAvailButtons.UseCompatibleStateImageBehavior = false;
             this.lvAvailButtons.SelectedIndexChanged += new System.EventHandler(this.lvAvailButtons_SelectedIndexChanged);
@@ -2354,10 +2370,10 @@ namespace ImageGlass
             this.lblUsedBtns.AutoSize = true;
             this.lblUsedBtns.BackColor = System.Drawing.Color.Transparent;
             this.lblUsedBtns.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblUsedBtns.Location = new System.Drawing.Point(370, 7);
+            this.lblUsedBtns.Location = new System.Drawing.Point(398, 8);
             this.lblUsedBtns.Margin = new System.Windows.Forms.Padding(1, 4, 1, 4);
             this.lblUsedBtns.Name = "lblUsedBtns";
-            this.lblUsedBtns.Size = new System.Drawing.Size(146, 23);
+            this.lblUsedBtns.Size = new System.Drawing.Size(150, 25);
             this.lblUsedBtns.TabIndex = 8;
             this.lblUsedBtns.Text = "[Current Buttons:]";
             // 
@@ -2370,12 +2386,12 @@ namespace ImageGlass
             this.lvUsedButtons.ForeColor = System.Drawing.SystemColors.Window;
             this.lvUsedButtons.FullRowSelect = true;
             this.lvUsedButtons.HideSelection = false;
-            this.lvUsedButtons.Location = new System.Drawing.Point(375, 40);
+            this.lvUsedButtons.Location = new System.Drawing.Point(403, 43);
             this.lvUsedButtons.Margin = new System.Windows.Forms.Padding(4);
             this.lvUsedButtons.Name = "lvUsedButtons";
             this.lvUsedButtons.ShowGroups = false;
             this.lvUsedButtons.ShowItemToolTips = true;
-            this.lvUsedButtons.Size = new System.Drawing.Size(279, 330);
+            this.lvUsedButtons.Size = new System.Drawing.Size(300, 357);
             this.lvUsedButtons.TabIndex = 54;
             this.lvUsedButtons.UseCompatibleStateImageBehavior = false;
             this.lvUsedButtons.View = System.Windows.Forms.View.List;
@@ -2387,10 +2403,10 @@ namespace ImageGlass
             this.btnMoveDown.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.btnMoveDown.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.btnMoveDown.Font = new System.Drawing.Font("Arial", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnMoveDown.Location = new System.Drawing.Point(669, 233);
+            this.btnMoveDown.Location = new System.Drawing.Point(719, 251);
             this.btnMoveDown.Margin = new System.Windows.Forms.Padding(4);
             this.btnMoveDown.Name = "btnMoveDown";
-            this.btnMoveDown.Size = new System.Drawing.Size(46, 46);
+            this.btnMoveDown.Size = new System.Drawing.Size(49, 49);
             this.btnMoveDown.TabIndex = 56;
             this.btnMoveDown.Text = "▼";
             this.btnMoveDown.UseVisualStyleBackColor = true;
@@ -2416,10 +2432,10 @@ namespace ImageGlass
             this.tabTools.Controls.Add(this.lblColorPicker);
             this.tabTools.Controls.Add(this.chkColorUseHEXA);
             this.tabTools.Controls.Add(this.chkColorUseRGBA);
-            this.tabTools.Location = new System.Drawing.Point(4, 69);
+            this.tabTools.Location = new System.Drawing.Point(4, 73);
             this.tabTools.Margin = new System.Windows.Forms.Padding(0);
             this.tabTools.Name = "tabTools";
-            this.tabTools.Size = new System.Drawing.Size(744, 596);
+            this.tabTools.Size = new System.Drawing.Size(801, 642);
             this.tabTools.TabIndex = 5;
             this.tabTools.Text = "tools";
             // 
@@ -2427,52 +2443,52 @@ namespace ImageGlass
             // 
             this.txtExifToolCommandPreview.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(198)))), ((int)(((byte)(203)))), ((int)(((byte)(204)))));
             this.txtExifToolCommandPreview.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtExifToolCommandPreview.Location = new System.Drawing.Point(44, 607);
-            this.txtExifToolCommandPreview.Margin = new System.Windows.Forms.Padding(0, 21, 0, 0);
+            this.txtExifToolCommandPreview.Location = new System.Drawing.Point(47, 652);
+            this.txtExifToolCommandPreview.Margin = new System.Windows.Forms.Padding(0, 23, 0, 0);
             this.txtExifToolCommandPreview.Multiline = true;
             this.txtExifToolCommandPreview.Name = "txtExifToolCommandPreview";
             this.txtExifToolCommandPreview.ReadOnly = true;
             this.txtExifToolCommandPreview.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtExifToolCommandPreview.Size = new System.Drawing.Size(529, 111);
+            this.txtExifToolCommandPreview.Size = new System.Drawing.Size(568, 119);
             this.txtExifToolCommandPreview.TabIndex = 71;
             this.txtExifToolCommandPreview.Text = "exiftool.exe -fast -G -t -m -q \"C:\\my\\photo.jpg\"";
             // 
             // lblExifToolCommandPreview
             // 
             this.lblExifToolCommandPreview.AutoSize = true;
-            this.lblExifToolCommandPreview.Location = new System.Drawing.Point(38, 576);
+            this.lblExifToolCommandPreview.Location = new System.Drawing.Point(41, 619);
             this.lblExifToolCommandPreview.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblExifToolCommandPreview.Name = "lblExifToolCommandPreview";
-            this.lblExifToolCommandPreview.Size = new System.Drawing.Size(157, 23);
+            this.lblExifToolCommandPreview.Size = new System.Drawing.Size(166, 25);
             this.lblExifToolCommandPreview.TabIndex = 65;
             this.lblExifToolCommandPreview.Text = "Command preview:";
             // 
             // panel10
             // 
-            this.panel10.Location = new System.Drawing.Point(84, 719);
+            this.panel10.Location = new System.Drawing.Point(90, 780);
             this.panel10.Margin = new System.Windows.Forms.Padding(1);
             this.panel10.Name = "panel10";
-            this.panel10.Size = new System.Drawing.Size(102, 29);
+            this.panel10.Size = new System.Drawing.Size(110, 31);
             this.panel10.TabIndex = 64;
             // 
             // txtExifToolCommandArgs
             // 
             this.txtExifToolCommandArgs.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(221)))), ((int)(((byte)(224)))), ((int)(((byte)(225)))));
-            this.txtExifToolCommandArgs.Location = new System.Drawing.Point(44, 491);
+            this.txtExifToolCommandArgs.Location = new System.Drawing.Point(47, 528);
             this.txtExifToolCommandArgs.Margin = new System.Windows.Forms.Padding(4);
             this.txtExifToolCommandArgs.Multiline = true;
             this.txtExifToolCommandArgs.Name = "txtExifToolCommandArgs";
             this.txtExifToolCommandArgs.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtExifToolCommandArgs.Size = new System.Drawing.Size(529, 65);
+            this.txtExifToolCommandArgs.Size = new System.Drawing.Size(568, 70);
             this.txtExifToolCommandArgs.TabIndex = 63;
             // 
             // lblExifToolCommandArgs
             // 
             this.lblExifToolCommandArgs.AutoSize = true;
-            this.lblExifToolCommandArgs.Location = new System.Drawing.Point(38, 465);
+            this.lblExifToolCommandArgs.Location = new System.Drawing.Point(41, 500);
             this.lblExifToolCommandArgs.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblExifToolCommandArgs.Name = "lblExifToolCommandArgs";
-            this.lblExifToolCommandArgs.Size = new System.Drawing.Size(181, 23);
+            this.lblExifToolCommandArgs.Size = new System.Drawing.Size(190, 25);
             this.lblExifToolCommandArgs.TabIndex = 62;
             this.lblExifToolCommandArgs.Text = "Command arguments:";
             // 
@@ -2480,10 +2496,10 @@ namespace ImageGlass
             // 
             this.chkColorUseHSVA.AutoSize = true;
             this.chkColorUseHSVA.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkColorUseHSVA.Location = new System.Drawing.Point(44, 151);
+            this.chkColorUseHSVA.Location = new System.Drawing.Point(47, 162);
             this.chkColorUseHSVA.Margin = new System.Windows.Forms.Padding(1);
             this.chkColorUseHSVA.Name = "chkColorUseHSVA";
-            this.chkColorUseHSVA.Size = new System.Drawing.Size(186, 28);
+            this.chkColorUseHSVA.Size = new System.Drawing.Size(198, 30);
             this.chkColorUseHSVA.TabIndex = 58;
             this.chkColorUseHSVA.Text = "[Use HSVA format]";
             this.chkColorUseHSVA.UseVisualStyleBackColor = true;
@@ -2493,10 +2509,10 @@ namespace ImageGlass
             this.lnkSelectExifTool.ActiveLinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(56)))), ((int)(((byte)(108)))), ((int)(((byte)(177)))));
             this.lnkSelectExifTool.AutoSize = true;
             this.lnkSelectExifTool.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkSelectExifTool.Location = new System.Drawing.Point(38, 386);
+            this.lnkSelectExifTool.Location = new System.Drawing.Point(41, 415);
             this.lnkSelectExifTool.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkSelectExifTool.Name = "lnkSelectExifTool";
-            this.lnkSelectExifTool.Size = new System.Drawing.Size(148, 23);
+            this.lnkSelectExifTool.Size = new System.Drawing.Size(155, 25);
             this.lnkSelectExifTool.TabIndex = 61;
             this.lnkSelectExifTool.TabStop = true;
             this.lnkSelectExifTool.Text = "Select Exif tool file";
@@ -2507,10 +2523,10 @@ namespace ImageGlass
             // 
             this.lblExifToolPath.AutoSize = true;
             this.lblExifToolPath.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblExifToolPath.Location = new System.Drawing.Point(38, 413);
+            this.lblExifToolPath.Location = new System.Drawing.Point(41, 444);
             this.lblExifToolPath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblExifToolPath.Name = "lblExifToolPath";
-            this.lblExifToolPath.Size = new System.Drawing.Size(186, 23);
+            this.lblExifToolPath.Size = new System.Drawing.Size(197, 25);
             this.lblExifToolPath.TabIndex = 61;
             this.lblExifToolPath.Text = "C:\\aaa\\bbb\\exiftool.exe";
             // 
@@ -2518,10 +2534,10 @@ namespace ImageGlass
             // 
             this.lblExifTool.AutoSize = true;
             this.lblExifTool.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblExifTool.Location = new System.Drawing.Point(22, 312);
+            this.lblExifTool.Location = new System.Drawing.Point(24, 335);
             this.lblExifTool.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblExifTool.Name = "lblExifTool";
-            this.lblExifTool.Size = new System.Drawing.Size(89, 23);
+            this.lblExifTool.Size = new System.Drawing.Size(97, 25);
             this.lblExifTool.TabIndex = 59;
             this.lblExifTool.Text = "[Exif tool]";
             // 
@@ -2529,10 +2545,10 @@ namespace ImageGlass
             // 
             this.chkExifToolAlwaysOnTop.AutoSize = true;
             this.chkExifToolAlwaysOnTop.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkExifToolAlwaysOnTop.Location = new System.Drawing.Point(44, 341);
+            this.chkExifToolAlwaysOnTop.Location = new System.Drawing.Point(47, 366);
             this.chkExifToolAlwaysOnTop.Margin = new System.Windows.Forms.Padding(1);
             this.chkExifToolAlwaysOnTop.Name = "chkExifToolAlwaysOnTop";
-            this.chkExifToolAlwaysOnTop.Size = new System.Drawing.Size(269, 28);
+            this.chkExifToolAlwaysOnTop.Size = new System.Drawing.Size(284, 30);
             this.chkExifToolAlwaysOnTop.TabIndex = 60;
             this.chkExifToolAlwaysOnTop.Text = "[Keep Exif tool always on top]";
             this.chkExifToolAlwaysOnTop.UseVisualStyleBackColor = true;
@@ -2541,10 +2557,10 @@ namespace ImageGlass
             // 
             this.lblPageNav.AutoSize = true;
             this.lblPageNav.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblPageNav.Location = new System.Drawing.Point(22, 212);
+            this.lblPageNav.Location = new System.Drawing.Point(24, 228);
             this.lblPageNav.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblPageNav.Name = "lblPageNav";
-            this.lblPageNav.Size = new System.Drawing.Size(151, 23);
+            this.lblPageNav.Size = new System.Drawing.Size(164, 25);
             this.lblPageNav.TabIndex = 58;
             this.lblPageNav.Text = "[Page navigation]";
             // 
@@ -2552,10 +2568,10 @@ namespace ImageGlass
             // 
             this.chkShowPageNavAuto.AutoSize = true;
             this.chkShowPageNavAuto.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkShowPageNavAuto.Location = new System.Drawing.Point(44, 241);
+            this.chkShowPageNavAuto.Location = new System.Drawing.Point(47, 259);
             this.chkShowPageNavAuto.Margin = new System.Windows.Forms.Padding(1);
             this.chkShowPageNavAuto.Name = "chkShowPageNavAuto";
-            this.chkShowPageNavAuto.Size = new System.Drawing.Size(467, 28);
+            this.chkShowPageNavAuto.Size = new System.Drawing.Size(490, 30);
             this.chkShowPageNavAuto.TabIndex = 59;
             this.chkShowPageNavAuto.Text = "[Auto-show Page navigation tool for multi-page image]";
             this.chkShowPageNavAuto.UseVisualStyleBackColor = true;
@@ -2564,10 +2580,10 @@ namespace ImageGlass
             // 
             this.chkColorUseHSLA.AutoSize = true;
             this.chkColorUseHSLA.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkColorUseHSLA.Location = new System.Drawing.Point(44, 116);
+            this.chkColorUseHSLA.Location = new System.Drawing.Point(47, 125);
             this.chkColorUseHSLA.Margin = new System.Windows.Forms.Padding(1);
             this.chkColorUseHSLA.Name = "chkColorUseHSLA";
-            this.chkColorUseHSLA.Size = new System.Drawing.Size(174, 28);
+            this.chkColorUseHSLA.Size = new System.Drawing.Size(187, 30);
             this.chkColorUseHSLA.TabIndex = 57;
             this.chkColorUseHSLA.Text = "Use HSLA format";
             this.chkColorUseHSLA.UseVisualStyleBackColor = true;
@@ -2576,10 +2592,10 @@ namespace ImageGlass
             // 
             this.lblColorPicker.AutoSize = true;
             this.lblColorPicker.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblColorPicker.Location = new System.Drawing.Point(22, 21);
+            this.lblColorPicker.Location = new System.Drawing.Point(24, 23);
             this.lblColorPicker.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblColorPicker.Name = "lblColorPicker";
-            this.lblColorPicker.Size = new System.Drawing.Size(120, 23);
+            this.lblColorPicker.Size = new System.Drawing.Size(128, 25);
             this.lblColorPicker.TabIndex = 47;
             this.lblColorPicker.Text = "[Color picker]";
             // 
@@ -2587,10 +2603,10 @@ namespace ImageGlass
             // 
             this.chkColorUseHEXA.AutoSize = true;
             this.chkColorUseHEXA.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkColorUseHEXA.Location = new System.Drawing.Point(44, 81);
+            this.chkColorUseHEXA.Location = new System.Drawing.Point(47, 87);
             this.chkColorUseHEXA.Margin = new System.Windows.Forms.Padding(1);
             this.chkColorUseHEXA.Name = "chkColorUseHEXA";
-            this.chkColorUseHEXA.Size = new System.Drawing.Size(249, 28);
+            this.chkColorUseHEXA.Size = new System.Drawing.Size(262, 30);
             this.chkColorUseHEXA.TabIndex = 56;
             this.chkColorUseHEXA.Text = "Use HEX with alpha format";
             this.chkColorUseHEXA.UseVisualStyleBackColor = true;
@@ -2599,10 +2615,10 @@ namespace ImageGlass
             // 
             this.chkColorUseRGBA.AutoSize = true;
             this.chkColorUseRGBA.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.chkColorUseRGBA.Location = new System.Drawing.Point(44, 46);
+            this.chkColorUseRGBA.Location = new System.Drawing.Point(47, 49);
             this.chkColorUseRGBA.Margin = new System.Windows.Forms.Padding(1);
             this.chkColorUseRGBA.Name = "chkColorUseRGBA";
-            this.chkColorUseRGBA.Size = new System.Drawing.Size(177, 28);
+            this.chkColorUseRGBA.Size = new System.Drawing.Size(188, 30);
             this.chkColorUseRGBA.TabIndex = 55;
             this.chkColorUseRGBA.Text = "Use RGBA format";
             this.chkColorUseRGBA.UseVisualStyleBackColor = true;
@@ -2619,20 +2635,20 @@ namespace ImageGlass
             this.tabKeyboard.Controls.Add(this.lblKeysPageUpDown);
             this.tabKeyboard.Controls.Add(this.lblKeysUpDown);
             this.tabKeyboard.Controls.Add(this.lblKeysLeftRight);
-            this.tabKeyboard.Location = new System.Drawing.Point(4, 69);
+            this.tabKeyboard.Location = new System.Drawing.Point(4, 73);
             this.tabKeyboard.Margin = new System.Windows.Forms.Padding(4);
             this.tabKeyboard.Name = "tabKeyboard";
             this.tabKeyboard.Padding = new System.Windows.Forms.Padding(4);
-            this.tabKeyboard.Size = new System.Drawing.Size(744, 596);
+            this.tabKeyboard.Size = new System.Drawing.Size(801, 642);
             this.tabKeyboard.TabIndex = 8;
             this.tabKeyboard.Text = "keyboard";
             // 
             // btnKeyReset
             // 
-            this.btnKeyReset.Location = new System.Drawing.Point(28, 420);
+            this.btnKeyReset.Location = new System.Drawing.Point(30, 451);
             this.btnKeyReset.Margin = new System.Windows.Forms.Padding(4);
             this.btnKeyReset.Name = "btnKeyReset";
-            this.btnKeyReset.Size = new System.Drawing.Size(261, 44);
+            this.btnKeyReset.Size = new System.Drawing.Size(280, 47);
             this.btnKeyReset.TabIndex = 77;
             this.btnKeyReset.Text = "[Reset to default]";
             this.btnKeyReset.UseVisualStyleBackColor = true;
@@ -2643,10 +2659,10 @@ namespace ImageGlass
             this.cmbKeysSpaceBack.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbKeysSpaceBack.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.cmbKeysSpaceBack.FormattingEnabled = true;
-            this.cmbKeysSpaceBack.Location = new System.Drawing.Point(28, 279);
+            this.cmbKeysSpaceBack.Location = new System.Drawing.Point(30, 300);
             this.cmbKeysSpaceBack.Margin = new System.Windows.Forms.Padding(4);
             this.cmbKeysSpaceBack.Name = "cmbKeysSpaceBack";
-            this.cmbKeysSpaceBack.Size = new System.Drawing.Size(260, 31);
+            this.cmbKeysSpaceBack.Size = new System.Drawing.Size(279, 33);
             this.cmbKeysSpaceBack.TabIndex = 76;
             // 
             // cmbKeysPgUpDown
@@ -2654,10 +2670,10 @@ namespace ImageGlass
             this.cmbKeysPgUpDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbKeysPgUpDown.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.cmbKeysPgUpDown.FormattingEnabled = true;
-            this.cmbKeysPgUpDown.Location = new System.Drawing.Point(28, 201);
+            this.cmbKeysPgUpDown.Location = new System.Drawing.Point(30, 216);
             this.cmbKeysPgUpDown.Margin = new System.Windows.Forms.Padding(4);
             this.cmbKeysPgUpDown.Name = "cmbKeysPgUpDown";
-            this.cmbKeysPgUpDown.Size = new System.Drawing.Size(260, 31);
+            this.cmbKeysPgUpDown.Size = new System.Drawing.Size(279, 33);
             this.cmbKeysPgUpDown.TabIndex = 75;
             // 
             // cmbKeysUpDown
@@ -2665,10 +2681,10 @@ namespace ImageGlass
             this.cmbKeysUpDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbKeysUpDown.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.cmbKeysUpDown.FormattingEnabled = true;
-            this.cmbKeysUpDown.Location = new System.Drawing.Point(28, 123);
+            this.cmbKeysUpDown.Location = new System.Drawing.Point(30, 132);
             this.cmbKeysUpDown.Margin = new System.Windows.Forms.Padding(4);
             this.cmbKeysUpDown.Name = "cmbKeysUpDown";
-            this.cmbKeysUpDown.Size = new System.Drawing.Size(260, 31);
+            this.cmbKeysUpDown.Size = new System.Drawing.Size(279, 33);
             this.cmbKeysUpDown.TabIndex = 74;
             // 
             // cmbKeysLeftRight
@@ -2676,49 +2692,49 @@ namespace ImageGlass
             this.cmbKeysLeftRight.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbKeysLeftRight.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.cmbKeysLeftRight.FormattingEnabled = true;
-            this.cmbKeysLeftRight.Location = new System.Drawing.Point(28, 45);
+            this.cmbKeysLeftRight.Location = new System.Drawing.Point(30, 48);
             this.cmbKeysLeftRight.Margin = new System.Windows.Forms.Padding(4);
             this.cmbKeysLeftRight.Name = "cmbKeysLeftRight";
-            this.cmbKeysLeftRight.Size = new System.Drawing.Size(260, 31);
+            this.cmbKeysLeftRight.Size = new System.Drawing.Size(279, 33);
             this.cmbKeysLeftRight.TabIndex = 73;
             // 
             // lblKeysSpaceBack
             // 
             this.lblKeysSpaceBack.AutoSize = true;
-            this.lblKeysSpaceBack.Location = new System.Drawing.Point(22, 252);
+            this.lblKeysSpaceBack.Location = new System.Drawing.Point(24, 271);
             this.lblKeysSpaceBack.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblKeysSpaceBack.Name = "lblKeysSpaceBack";
-            this.lblKeysSpaceBack.Size = new System.Drawing.Size(160, 23);
+            this.lblKeysSpaceBack.Size = new System.Drawing.Size(167, 25);
             this.lblKeysSpaceBack.TabIndex = 4;
             this.lblKeysSpaceBack.Text = "[Space / Backspace]";
             // 
             // lblKeysPageUpDown
             // 
             this.lblKeysPageUpDown.AutoSize = true;
-            this.lblKeysPageUpDown.Location = new System.Drawing.Point(22, 174);
+            this.lblKeysPageUpDown.Location = new System.Drawing.Point(24, 187);
             this.lblKeysPageUpDown.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblKeysPageUpDown.Name = "lblKeysPageUpDown";
-            this.lblKeysPageUpDown.Size = new System.Drawing.Size(177, 23);
+            this.lblKeysPageUpDown.Size = new System.Drawing.Size(185, 25);
             this.lblKeysPageUpDown.TabIndex = 3;
             this.lblKeysPageUpDown.Text = "[PageUp / PageDown]";
             // 
             // lblKeysUpDown
             // 
             this.lblKeysUpDown.AutoSize = true;
-            this.lblKeysUpDown.Location = new System.Drawing.Point(22, 96);
+            this.lblKeysUpDown.Location = new System.Drawing.Point(24, 103);
             this.lblKeysUpDown.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblKeysUpDown.Name = "lblKeysUpDown";
-            this.lblKeysUpDown.Size = new System.Drawing.Size(158, 23);
+            this.lblKeysUpDown.Size = new System.Drawing.Size(167, 25);
             this.lblKeysUpDown.TabIndex = 2;
             this.lblKeysUpDown.Text = "[Up / Down arrows]";
             // 
             // lblKeysLeftRight
             // 
             this.lblKeysLeftRight.AutoSize = true;
-            this.lblKeysLeftRight.Location = new System.Drawing.Point(22, 21);
+            this.lblKeysLeftRight.Location = new System.Drawing.Point(24, 23);
             this.lblKeysLeftRight.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblKeysLeftRight.Name = "lblKeysLeftRight";
-            this.lblKeysLeftRight.Size = new System.Drawing.Size(160, 23);
+            this.lblKeysLeftRight.Size = new System.Drawing.Size(168, 25);
             this.lblKeysLeftRight.TabIndex = 1;
             this.lblKeysLeftRight.Text = "[Left / Right arrows]";
             // 
@@ -2727,11 +2743,11 @@ namespace ImageGlass
             this.tabTheme.AutoScroll = true;
             this.tabTheme.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(198)))), ((int)(((byte)(203)))), ((int)(((byte)(204)))));
             this.tabTheme.Controls.Add(this.tableTheme);
-            this.tabTheme.Location = new System.Drawing.Point(4, 69);
+            this.tabTheme.Location = new System.Drawing.Point(4, 73);
             this.tabTheme.Margin = new System.Windows.Forms.Padding(0);
             this.tabTheme.Name = "tabTheme";
-            this.tabTheme.Padding = new System.Windows.Forms.Padding(22, 21, 22, 21);
-            this.tabTheme.Size = new System.Drawing.Size(744, 596);
+            this.tabTheme.Padding = new System.Windows.Forms.Padding(24, 23, 24, 23);
+            this.tabTheme.Size = new System.Drawing.Size(801, 642);
             this.tabTheme.TabIndex = 6;
             this.tabTheme.Text = "Theme";
             // 
@@ -2746,14 +2762,14 @@ namespace ImageGlass
             this.tableTheme.Controls.Add(this.lvTheme, 0, 1);
             this.tableTheme.Controls.Add(this.btnThemeApply, 1, 2);
             this.tableTheme.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableTheme.Location = new System.Drawing.Point(22, 21);
+            this.tableTheme.Location = new System.Drawing.Point(24, 23);
             this.tableTheme.Margin = new System.Windows.Forms.Padding(4);
             this.tableTheme.Name = "tableTheme";
             this.tableTheme.RowCount = 3;
             this.tableTheme.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableTheme.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableTheme.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableTheme.Size = new System.Drawing.Size(700, 554);
+            this.tableTheme.Size = new System.Drawing.Size(753, 596);
             this.tableTheme.TabIndex = 73;
             // 
             // lblInstalledThemes
@@ -2762,7 +2778,7 @@ namespace ImageGlass
             this.lblInstalledThemes.Location = new System.Drawing.Point(0, 0);
             this.lblInstalledThemes.Margin = new System.Windows.Forms.Padding(0, 0, 1, 6);
             this.lblInstalledThemes.Name = "lblInstalledThemes";
-            this.lblInstalledThemes.Size = new System.Drawing.Size(139, 23);
+            this.lblInstalledThemes.Size = new System.Drawing.Size(145, 25);
             this.lblInstalledThemes.TabIndex = 2;
             this.lblInstalledThemes.Text = "Installed themes:";
             // 
@@ -2771,10 +2787,10 @@ namespace ImageGlass
             this.panelThemeActions.AutoScroll = true;
             this.panelThemeActions.Controls.Add(this.tb3);
             this.panelThemeActions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelThemeActions.Location = new System.Drawing.Point(400, 29);
+            this.panelThemeActions.Location = new System.Drawing.Point(431, 31);
             this.panelThemeActions.Margin = new System.Windows.Forms.Padding(0);
             this.panelThemeActions.Name = "panelThemeActions";
-            this.panelThemeActions.Size = new System.Drawing.Size(300, 460);
+            this.panelThemeActions.Size = new System.Drawing.Size(322, 495);
             this.panelThemeActions.TabIndex = 29;
             // 
             // tb3
@@ -2800,7 +2816,7 @@ namespace ImageGlass
             this.tb3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tb3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tb3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tb3.Size = new System.Drawing.Size(300, 460);
+            this.tb3.Size = new System.Drawing.Size(322, 495);
             this.tb3.TabIndex = 71;
             // 
             // picPreview
@@ -2811,7 +2827,7 @@ namespace ImageGlass
             this.picPreview.Location = new System.Drawing.Point(0, 4);
             this.picPreview.Margin = new System.Windows.Forms.Padding(0, 4, 0, 0);
             this.picPreview.Name = "picPreview";
-            this.picPreview.Size = new System.Drawing.Size(300, 150);
+            this.picPreview.Size = new System.Drawing.Size(322, 161);
             this.picPreview.TabIndex = 34;
             this.picPreview.TabStop = false;
             // 
@@ -2820,12 +2836,12 @@ namespace ImageGlass
             this.txtThemeInfo.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(198)))), ((int)(((byte)(203)))), ((int)(((byte)(204)))));
             this.txtThemeInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.txtThemeInfo.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.txtThemeInfo.Location = new System.Drawing.Point(0, 420);
-            this.txtThemeInfo.Margin = new System.Windows.Forms.Padding(0, 21, 0, 0);
+            this.txtThemeInfo.Location = new System.Drawing.Point(0, 450);
+            this.txtThemeInfo.Margin = new System.Windows.Forms.Padding(0, 23, 0, 0);
             this.txtThemeInfo.Multiline = true;
             this.txtThemeInfo.Name = "txtThemeInfo";
             this.txtThemeInfo.ReadOnly = true;
-            this.txtThemeInfo.Size = new System.Drawing.Size(300, 63);
+            this.txtThemeInfo.Size = new System.Drawing.Size(322, 68);
             this.txtThemeInfo.TabIndex = 70;
             // 
             // btnThemeFolderOpen
@@ -2834,10 +2850,10 @@ namespace ImageGlass
             | System.Windows.Forms.AnchorStyles.Right)));
             this.btnThemeFolderOpen.AutoSize = true;
             this.btnThemeFolderOpen.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnThemeFolderOpen.Location = new System.Drawing.Point(0, 359);
+            this.btnThemeFolderOpen.Location = new System.Drawing.Point(0, 384);
             this.btnThemeFolderOpen.Margin = new System.Windows.Forms.Padding(0, 6, 0, 0);
             this.btnThemeFolderOpen.Name = "btnThemeFolderOpen";
-            this.btnThemeFolderOpen.Size = new System.Drawing.Size(300, 40);
+            this.btnThemeFolderOpen.Size = new System.Drawing.Size(322, 43);
             this.btnThemeFolderOpen.TabIndex = 69;
             this.btnThemeFolderOpen.Text = "Open theme folder";
             this.btnThemeFolderOpen.UseVisualStyleBackColor = true;
@@ -2849,10 +2865,10 @@ namespace ImageGlass
             | System.Windows.Forms.AnchorStyles.Right)));
             this.btnThemeRefresh.AutoSize = true;
             this.btnThemeRefresh.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnThemeRefresh.Location = new System.Drawing.Point(0, 175);
-            this.btnThemeRefresh.Margin = new System.Windows.Forms.Padding(0, 21, 0, 0);
+            this.btnThemeRefresh.Location = new System.Drawing.Point(0, 188);
+            this.btnThemeRefresh.Margin = new System.Windows.Forms.Padding(0, 23, 0, 0);
             this.btnThemeRefresh.Name = "btnThemeRefresh";
-            this.btnThemeRefresh.Size = new System.Drawing.Size(300, 40);
+            this.btnThemeRefresh.Size = new System.Drawing.Size(322, 43);
             this.btnThemeRefresh.TabIndex = 65;
             this.btnThemeRefresh.Text = "Refresh";
             this.btnThemeRefresh.UseVisualStyleBackColor = true;
@@ -2864,10 +2880,10 @@ namespace ImageGlass
             | System.Windows.Forms.AnchorStyles.Right)));
             this.btnThemeSaveAs.AutoSize = true;
             this.btnThemeSaveAs.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnThemeSaveAs.Location = new System.Drawing.Point(0, 313);
+            this.btnThemeSaveAs.Location = new System.Drawing.Point(0, 335);
             this.btnThemeSaveAs.Margin = new System.Windows.Forms.Padding(0, 6, 0, 0);
             this.btnThemeSaveAs.Name = "btnThemeSaveAs";
-            this.btnThemeSaveAs.Size = new System.Drawing.Size(300, 40);
+            this.btnThemeSaveAs.Size = new System.Drawing.Size(322, 43);
             this.btnThemeSaveAs.TabIndex = 68;
             this.btnThemeSaveAs.Text = "Save As";
             this.btnThemeSaveAs.UseVisualStyleBackColor = true;
@@ -2879,10 +2895,10 @@ namespace ImageGlass
             | System.Windows.Forms.AnchorStyles.Right)));
             this.btnThemeInstall.AutoSize = true;
             this.btnThemeInstall.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnThemeInstall.Location = new System.Drawing.Point(0, 221);
+            this.btnThemeInstall.Location = new System.Drawing.Point(0, 237);
             this.btnThemeInstall.Margin = new System.Windows.Forms.Padding(0, 6, 0, 0);
             this.btnThemeInstall.Name = "btnThemeInstall";
-            this.btnThemeInstall.Size = new System.Drawing.Size(300, 40);
+            this.btnThemeInstall.Size = new System.Drawing.Size(322, 43);
             this.btnThemeInstall.TabIndex = 66;
             this.btnThemeInstall.Text = "Install";
             this.btnThemeInstall.UseVisualStyleBackColor = true;
@@ -2895,10 +2911,10 @@ namespace ImageGlass
             this.btnThemeUninstall.AutoSize = true;
             this.btnThemeUninstall.Enabled = false;
             this.btnThemeUninstall.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnThemeUninstall.Location = new System.Drawing.Point(0, 267);
+            this.btnThemeUninstall.Location = new System.Drawing.Point(0, 286);
             this.btnThemeUninstall.Margin = new System.Windows.Forms.Padding(0, 6, 0, 0);
             this.btnThemeUninstall.Name = "btnThemeUninstall";
-            this.btnThemeUninstall.Size = new System.Drawing.Size(300, 40);
+            this.btnThemeUninstall.Size = new System.Drawing.Size(322, 43);
             this.btnThemeUninstall.TabIndex = 67;
             this.btnThemeUninstall.Text = "Uninstall";
             this.btnThemeUninstall.UseVisualStyleBackColor = true;
@@ -2912,10 +2928,10 @@ namespace ImageGlass
             this.lnkThemeDownload.BackColor = System.Drawing.Color.Transparent;
             this.lnkThemeDownload.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkThemeDownload.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkThemeDownload.Location = new System.Drawing.Point(4, 520);
-            this.lnkThemeDownload.Margin = new System.Windows.Forms.Padding(4, 21, 4, 0);
+            this.lnkThemeDownload.Location = new System.Drawing.Point(4, 560);
+            this.lnkThemeDownload.Margin = new System.Windows.Forms.Padding(4, 23, 4, 0);
             this.lnkThemeDownload.Name = "lnkThemeDownload";
-            this.lnkThemeDownload.Size = new System.Drawing.Size(158, 23);
+            this.lnkThemeDownload.Size = new System.Drawing.Size(167, 25);
             this.lnkThemeDownload.TabIndex = 72;
             this.lnkThemeDownload.TabStop = true;
             this.lnkThemeDownload.Text = "[Download themes]";
@@ -2933,12 +2949,12 @@ namespace ImageGlass
             this.lvTheme.FullRowSelect = true;
             this.lvTheme.HideSelection = false;
             this.lvTheme.LargeImageList = this.imglGeneral;
-            this.lvTheme.Location = new System.Drawing.Point(4, 33);
-            this.lvTheme.Margin = new System.Windows.Forms.Padding(4, 4, 10, 4);
+            this.lvTheme.Location = new System.Drawing.Point(4, 35);
+            this.lvTheme.Margin = new System.Windows.Forms.Padding(4, 4, 11, 4);
             this.lvTheme.MultiSelect = false;
             this.lvTheme.Name = "lvTheme";
             this.lvTheme.ShowItemToolTips = true;
-            this.lvTheme.Size = new System.Drawing.Size(386, 452);
+            this.lvTheme.Size = new System.Drawing.Size(416, 487);
             this.lvTheme.SmallImageList = this.imglGeneral;
             this.lvTheme.StateImageList = this.imglGeneral;
             this.lvTheme.TabIndex = 64;
@@ -2951,10 +2967,10 @@ namespace ImageGlass
             this.btnThemeApply.AutoSize = true;
             this.btnThemeApply.Dock = System.Windows.Forms.DockStyle.Fill;
             this.btnThemeApply.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnThemeApply.Location = new System.Drawing.Point(400, 510);
-            this.btnThemeApply.Margin = new System.Windows.Forms.Padding(0, 21, 0, 4);
+            this.btnThemeApply.Location = new System.Drawing.Point(431, 549);
+            this.btnThemeApply.Margin = new System.Windows.Forms.Padding(0, 23, 0, 4);
             this.btnThemeApply.Name = "btnThemeApply";
-            this.btnThemeApply.Size = new System.Drawing.Size(300, 40);
+            this.btnThemeApply.Size = new System.Drawing.Size(322, 43);
             this.btnThemeApply.TabIndex = 71;
             this.btnThemeApply.Text = "Apply Theme";
             this.btnThemeApply.UseVisualStyleBackColor = true;
@@ -2974,12 +2990,24 @@ namespace ImageGlass
             this.tabLanguage.Controls.Add(this.lnkGetMoreLanguage);
             this.tabLanguage.Controls.Add(this.cmbLanguage);
             this.tabLanguage.Controls.Add(this.lblLanguageText);
-            this.tabLanguage.Location = new System.Drawing.Point(4, 69);
+            this.tabLanguage.Location = new System.Drawing.Point(4, 73);
             this.tabLanguage.Margin = new System.Windows.Forms.Padding(0);
             this.tabLanguage.Name = "tabLanguage";
-            this.tabLanguage.Size = new System.Drawing.Size(744, 596);
+            this.tabLanguage.Size = new System.Drawing.Size(801, 642);
             this.tabLanguage.TabIndex = 2;
             this.tabLanguage.Text = "Lang";
+            // 
+            // lblTranslatorNames
+            // 
+            this.lblTranslatorNames.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblTranslatorNames.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblTranslatorNames.Location = new System.Drawing.Point(47, 153);
+            this.lblTranslatorNames.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
+            this.lblTranslatorNames.Name = "lblTranslatorNames";
+            this.lblTranslatorNames.Size = new System.Drawing.Size(728, 80);
+            this.lblTranslatorNames.TabIndex = 65;
+            this.lblTranslatorNames.Text = "[aaa, \r\nbbb, \r\nccc]";
             // 
             // lblTranslators
             // 
@@ -2987,10 +3015,10 @@ namespace ImageGlass
             | System.Windows.Forms.AnchorStyles.Right)));
             this.lblTranslators.AutoSize = true;
             this.lblTranslators.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblTranslators.Location = new System.Drawing.Point(24, 111);
+            this.lblTranslators.Location = new System.Drawing.Point(26, 119);
             this.lblTranslators.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblTranslators.Name = "lblTranslators";
-            this.lblTranslators.Size = new System.Drawing.Size(114, 23);
+            this.lblTranslators.Size = new System.Drawing.Size(125, 25);
             this.lblTranslators.TabIndex = 64;
             this.lblTranslators.Text = "[Translators:]";
             // 
@@ -2999,10 +3027,10 @@ namespace ImageGlass
             this.lblLanguageWarning.AutoSize = true;
             this.lblLanguageWarning.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblLanguageWarning.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(115)))), ((int)(((byte)(17)))));
-            this.lblLanguageWarning.Location = new System.Drawing.Point(24, 81);
+            this.lblLanguageWarning.Location = new System.Drawing.Point(26, 87);
             this.lblLanguageWarning.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblLanguageWarning.Name = "lblLanguageWarning";
-            this.lblLanguageWarning.Size = new System.Drawing.Size(525, 23);
+            this.lblLanguageWarning.Size = new System.Drawing.Size(566, 25);
             this.lblLanguageWarning.TabIndex = 25;
             this.lblLanguageWarning.Text = "[This language pack may be not compatible with ImageGlass 3.2.0.16.]";
             this.lblLanguageWarning.Visible = false;
@@ -3013,10 +3041,10 @@ namespace ImageGlass
             this.lnkInstallLanguage.AutoSize = true;
             this.lnkInstallLanguage.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkInstallLanguage.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkInstallLanguage.Location = new System.Drawing.Point(22, 315);
+            this.lnkInstallLanguage.Location = new System.Drawing.Point(24, 339);
             this.lnkInstallLanguage.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lnkInstallLanguage.Name = "lnkInstallLanguage";
-            this.lnkInstallLanguage.Size = new System.Drawing.Size(297, 23);
+            this.lnkInstallLanguage.Size = new System.Drawing.Size(308, 25);
             this.lnkInstallLanguage.TabIndex = 60;
             this.lnkInstallLanguage.TabStop = true;
             this.lnkInstallLanguage.Text = "> Install new language pack (*.iglang)";
@@ -3029,10 +3057,10 @@ namespace ImageGlass
             this.lnkRefresh.AutoSize = true;
             this.lnkRefresh.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkRefresh.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkRefresh.Location = new System.Drawing.Point(432, 50);
+            this.lnkRefresh.Location = new System.Drawing.Point(464, 54);
             this.lnkRefresh.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lnkRefresh.Name = "lnkRefresh";
-            this.lnkRefresh.Size = new System.Drawing.Size(93, 23);
+            this.lnkRefresh.Size = new System.Drawing.Size(97, 25);
             this.lnkRefresh.TabIndex = 59;
             this.lnkRefresh.TabStop = true;
             this.lnkRefresh.Text = "[> Refresh]";
@@ -3045,10 +3073,10 @@ namespace ImageGlass
             this.lnkEdit.AutoSize = true;
             this.lnkEdit.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkEdit.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkEdit.Location = new System.Drawing.Point(22, 430);
+            this.lnkEdit.Location = new System.Drawing.Point(24, 462);
             this.lnkEdit.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lnkEdit.Name = "lnkEdit";
-            this.lnkEdit.Size = new System.Drawing.Size(239, 23);
+            this.lnkEdit.Size = new System.Drawing.Size(248, 25);
             this.lnkEdit.TabIndex = 62;
             this.lnkEdit.TabStop = true;
             this.lnkEdit.Text = "> Edit selected language pack";
@@ -3061,10 +3089,10 @@ namespace ImageGlass
             this.lnkCreateNew.AutoSize = true;
             this.lnkCreateNew.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkCreateNew.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkCreateNew.Location = new System.Drawing.Point(22, 348);
+            this.lnkCreateNew.Location = new System.Drawing.Point(24, 374);
             this.lnkCreateNew.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lnkCreateNew.Name = "lnkCreateNew";
-            this.lnkCreateNew.Size = new System.Drawing.Size(229, 23);
+            this.lnkCreateNew.Size = new System.Drawing.Size(236, 25);
             this.lnkCreateNew.TabIndex = 61;
             this.lnkCreateNew.TabStop = true;
             this.lnkCreateNew.Text = "> Create new language pack";
@@ -3077,10 +3105,10 @@ namespace ImageGlass
             this.lnkGetMoreLanguage.AutoSize = true;
             this.lnkGetMoreLanguage.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkGetMoreLanguage.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(125)))), ((int)(((byte)(208)))));
-            this.lnkGetMoreLanguage.Location = new System.Drawing.Point(22, 381);
+            this.lnkGetMoreLanguage.Location = new System.Drawing.Point(24, 409);
             this.lnkGetMoreLanguage.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lnkGetMoreLanguage.Name = "lnkGetMoreLanguage";
-            this.lnkGetMoreLanguage.Size = new System.Drawing.Size(222, 23);
+            this.lnkGetMoreLanguage.Size = new System.Drawing.Size(231, 25);
             this.lnkGetMoreLanguage.TabIndex = 63;
             this.lnkGetMoreLanguage.TabStop = true;
             this.lnkGetMoreLanguage.Text = "> Get more language packs";
@@ -3095,20 +3123,20 @@ namespace ImageGlass
             this.cmbLanguage.Items.AddRange(new object[] {
             "English (default)",
             "Vietnamese"});
-            this.cmbLanguage.Location = new System.Drawing.Point(28, 47);
+            this.cmbLanguage.Location = new System.Drawing.Point(30, 51);
             this.cmbLanguage.Margin = new System.Windows.Forms.Padding(1);
             this.cmbLanguage.Name = "cmbLanguage";
-            this.cmbLanguage.Size = new System.Drawing.Size(390, 31);
+            this.cmbLanguage.Size = new System.Drawing.Size(419, 33);
             this.cmbLanguage.TabIndex = 58;
             this.cmbLanguage.SelectedIndexChanged += new System.EventHandler(this.cmbLanguage_SelectedIndexChanged);
             // 
             // lblLanguageText
             // 
             this.lblLanguageText.AutoSize = true;
-            this.lblLanguageText.Location = new System.Drawing.Point(22, 21);
+            this.lblLanguageText.Location = new System.Drawing.Point(24, 23);
             this.lblLanguageText.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblLanguageText.Name = "lblLanguageText";
-            this.lblLanguageText.Size = new System.Drawing.Size(171, 23);
+            this.lblLanguageText.Size = new System.Drawing.Size(178, 25);
             this.lblLanguageText.TabIndex = 1;
             this.lblLanguageText.Text = "[Installed languages:]";
             // 
@@ -3117,10 +3145,10 @@ namespace ImageGlass
             this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnSave.AutoSize = true;
             this.btnSave.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnSave.Location = new System.Drawing.Point(542, 12);
+            this.btnSave.Location = new System.Drawing.Point(582, 13);
             this.btnSave.Margin = new System.Windows.Forms.Padding(4);
             this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(130, 44);
+            this.btnSave.Size = new System.Drawing.Size(140, 47);
             this.btnSave.TabIndex = 0;
             this.btnSave.Text = "Save";
             this.btnSave.UseVisualStyleBackColor = true;
@@ -3131,10 +3159,10 @@ namespace ImageGlass
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.AutoSize = true;
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnCancel.Location = new System.Drawing.Point(677, 12);
+            this.btnCancel.Location = new System.Drawing.Point(728, 13);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(4);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(130, 44);
+            this.btnCancel.Size = new System.Drawing.Size(140, 47);
             this.btnCancel.TabIndex = 1;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -3145,10 +3173,10 @@ namespace ImageGlass
             this.btnApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnApply.AutoSize = true;
             this.btnApply.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btnApply.Location = new System.Drawing.Point(816, 12);
+            this.btnApply.Location = new System.Drawing.Point(877, 13);
             this.btnApply.Margin = new System.Windows.Forms.Padding(4);
             this.btnApply.Name = "btnApply";
-            this.btnApply.Size = new System.Drawing.Size(130, 44);
+            this.btnApply.Size = new System.Drawing.Size(140, 47);
             this.btnApply.TabIndex = 2;
             this.btnApply.Text = "Apply";
             this.btnApply.UseVisualStyleBackColor = true;
@@ -3167,8 +3195,8 @@ namespace ImageGlass
             this.tblayout.Name = "tblayout";
             this.tblayout.RowCount = 2;
             this.tblayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tblayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 67F));
-            this.tblayout.Size = new System.Drawing.Size(973, 736);
+            this.tblayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 72F));
+            this.tblayout.Size = new System.Drawing.Size(1046, 791);
             this.tblayout.TabIndex = 19;
             // 
             // panel4
@@ -3178,36 +3206,24 @@ namespace ImageGlass
             this.panel4.Controls.Add(this.btnSave);
             this.panel4.Controls.Add(this.btnCancel);
             this.panel4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel4.Location = new System.Drawing.Point(0, 669);
+            this.panel4.Location = new System.Drawing.Point(0, 719);
             this.panel4.Margin = new System.Windows.Forms.Padding(0);
             this.panel4.Name = "panel4";
-            this.panel4.Size = new System.Drawing.Size(973, 67);
+            this.panel4.Size = new System.Drawing.Size(1046, 72);
             this.panel4.TabIndex = 18;
-            // 
-            // lblTranslatorNames
-            // 
-            this.lblTranslatorNames.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblTranslatorNames.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblTranslatorNames.Location = new System.Drawing.Point(44, 142);
-            this.lblTranslatorNames.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
-            this.lblTranslatorNames.Name = "lblTranslatorNames";
-            this.lblTranslatorNames.Size = new System.Drawing.Size(677, 74);
-            this.lblTranslatorNames.TabIndex = 65;
-            this.lblTranslatorNames.Text = "[aaa, \r\nbbb, \r\nccc]";
             // 
             // frmSetting
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(134F, 134F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(160)))), ((int)(((byte)(165)))), ((int)(((byte)(168)))));
-            this.ClientSize = new System.Drawing.Size(973, 736);
+            this.ClientSize = new System.Drawing.Size(1046, 791);
             this.Controls.Add(this.tblayout);
             this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.KeyPreview = true;
             this.Margin = new System.Windows.Forms.Padding(1);
-            this.MinimumSize = new System.Drawing.Size(636, 453);
+            this.MinimumSize = new System.Drawing.Size(682, 483);
             this.Name = "frmSetting";
             this.RightToLeftLayout = true;
             this.Text = "Settings";
@@ -3489,5 +3505,6 @@ namespace ImageGlass
         private System.Windows.Forms.CheckBox chkAutoDisplayNewImage;
         private System.Windows.Forms.Label lblTranslators;
         private System.Windows.Forms.Label lblTranslatorNames;
+        private System.Windows.Forms.CheckBox chkShowSetDesktopInContext;
     }
 }

--- a/Source/ImageGlass/frmSetting.cs
+++ b/Source/ImageGlass/frmSetting.cs
@@ -242,6 +242,7 @@ namespace ImageGlass {
             lblImageBoosterCachedCount.Text = lang[$"{Name}.{nameof(lblImageBoosterCachedCount)}"];
             chkIsPlayImageChangeSound.Text = lang[$"{Name}.{nameof(chkIsPlayImageChangeSound)}"];
             lblNumberImagesNotify.Text = lang[$"{Name}.{nameof(lblNumberImagesNotify)}"];
+            chkShowSetDesktopInContext.Text = lang[$"{Name}.{nameof(chkShowSetDesktopInContext)}"];
 
             lblColorManagement.Text = lang[$"{Name}.{nameof(lblColorManagement)}"];//
             chkApplyColorProfile.Text = lang[$"{Name}.{nameof(chkApplyColorProfile)}"];
@@ -581,6 +582,9 @@ namespace ImageGlass {
             // Number of Images after which sound is played
             chkIsPlayImageChangeSound.Checked = Configs.IsPlayImageChangeSound;
             numNumberImagesNotify.Value = Configs.NumberImagesNotify;
+
+            // Show set as desktop background in context menu
+            chkShowSetDesktopInContext.Checked = Configs.ShowSetDesktopInContext;
 
             #region Load items of cmbImageOrder
             var loadingOrderList = Enum.GetNames(typeof(ImageOrderBy));
@@ -1988,6 +1992,9 @@ namespace ImageGlass {
             // image changes alert
             Configs.IsPlayImageChangeSound = chkIsPlayImageChangeSound.Checked;
             Configs.NumberImagesNotify = (uint)numNumberImagesNotify.Value;
+
+            // show set as desktop background in context menu
+            Configs.ShowSetDesktopInContext = chkShowSetDesktopInContext.Checked;
 
             #region ImageLoadingOrder: MainFormForceUpdateAction.IMAGE_LIST
             newInt = cmbImageOrder.SelectedIndex;


### PR DESCRIPTION
Implemented issue #1498 by adding the option to disable the button that will set an image as the desktop background in the context menu.
If someone does not want to use that feature at all, you now can disable it to prevent unintended usage.
The option is activated by default.

The settings window looks like this:
<img width="827" alt="The settings window with the new option." src="https://user-images.githubusercontent.com/44812095/224965736-4d83df78-01ea-4b0c-b507-f4308d36d132.PNG">

