### PR TITLE
When image is actual size, highlight the actual size button

### DIFF
--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -3256,6 +3256,9 @@ namespace ImageGlass {
             // Trigger Mouse Wheel event
             picMain.MouseWheel += picMain_MouseWheel;
 
+            // Zoom level change event
+            picMain.ZoomChanged += picMain_ZoomChanged;
+
             // Try to use a faster image clock for animating GIFs
             CheckAnimationClock(true);
 
@@ -3835,6 +3838,11 @@ namespace ImageGlass {
 
             // draw navigation regions
             PaintNavigationRegions(e);
+        }
+
+        private void picMain_ZoomChanged(object sender, EventArgs e) {
+            // If zoom level is actual size, highlight actual size button
+            btnActualSize.Checked = picMain.IsActualSize;
         }
 
         #region File System Watcher events


### PR DESCRIPTION
A little thing I liked about the old windows photo viewer was the at-a-glance indication of whether the image was shown actual size. Granted in ImageGlass you could read the title bar for zoom level for every image you skim through, but it only took a little code to make the actual size button highlight when image was actual size. It seemed like all the parts were there, just not wired together yet.

To see this change in action, use settings to add the actual size button to the toolbar and whenever an image is shown actual size, the actual size button will be highlighted.