### PR TITLE
Add visual indication that image is already actual size

### DIFF
--- a/Setup/Assets/Themes/Kobe/ActualSize.svg
+++ b/Setup/Assets/Themes/Kobe/ActualSize.svg
@@ -1,16 +1,27 @@
-<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <clipPath id="clipPath2783">
+   <g display="none">
+    <rect x=".2892" y=".2892" width="7.5487" height="7.5487" d="M 0.289204,0.289204 H 7.8379148 V 7.8379148 H 0.289204 Z" fill="none" stroke="#999" stroke-width=".57841"/>
+    <rect x="12.162" y=".2892" width="7.5487" height="7.5487" d="m 12.162086,0.289204 h 7.54871 v 7.5487108 h -7.54871 z" fill="none" stroke="#999" stroke-width=".57841"/>
+    <rect x="12.162" y="12.162" width="7.5487" height="7.5487" d="m 12.162086,12.162086 h 7.54871 v 7.54871 h -7.54871 z" fill="none" stroke="#999" stroke-width=".57841"/>
+    <rect x=".2892" y="12.162" width="7.5487" height="7.5487" d="m 0.289204,12.162086 h 7.5487108 v 7.54871 H 0.289204 Z" fill="none" stroke="#999" stroke-width=".57841"/>
+   </g>
+   <path class="powerclip" d="m-3.0581-3.0581h26.116v26.116h-26.116zm3.3474 3.3474v7.5487h7.5487v-7.5487zm11.873 0v7.5487h7.5487v-7.5487zm0 11.873v7.5487h7.5487v-7.5487zm-11.873 0v7.5487h7.5487v-7.5487z"/>
+  </clipPath>
+ </defs>
  <!-- ImageGlass icons http://www.imageglass.org -->
-
  <g>
   <title>background</title>
-  <rect fill="none" id="canvas_background" height="22" width="22" y="-1" x="-1"/>
-  <g display="none" id="canvasGrid">
-   <rect id="svg_2" fill="url(#gridpattern)" stroke-width="0" y="0" x="0" height="100%" width="100%"/>
+  <rect id="canvas_background" x="-1" y="-1" width="22" height="22" fill="none"/>
+  <g id="canvasGrid" display="none">
+   <rect width="100%" height="100%" fill="url(#gridpattern)" stroke-width="0"/>
   </g>
  </g>
  <g>
   <title>Layer 1</title>
-  <ellipse stroke="#dedede" ry="7.899555" rx="7.899555" id="svg_9" cy="8.249556" cx="8.249555" fill-opacity="null" stroke-opacity="null" stroke-width="0.7" fill="none"/>
-  <line stroke="#dedede" stroke-linecap="null" stroke-linejoin="null" id="svg_11" y2="19.699652" x2="19.722484" y1="13.835621" x1="13.858454" fill-opacity="null" stroke-opacity="null" stroke-width="2" fill="none"/>
+  <rect x="5.7829" y="6.8183" width="8.4343" height="6.3635" fill="none" stroke="#dedede" stroke-width=".7"/>
+  <rect x="2.1919" y="2.1919" width="15.616" height="15.616" d="M 2.1918502,2.1918502 H 17.80815 V 17.80815 H 2.1918502 Z" clip-path="url(#clipPath2783)" fill="none" stroke="#dedede" stroke-width=".7"/>
  </g>
 </svg>

--- a/Setup/Assets/Themes/Kobe/ActualSizeAlready.svg
+++ b/Setup/Assets/Themes/Kobe/ActualSizeAlready.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20" height="20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <clipPath id="clipPath2753">
+   <rect x=".2892" y=".2892" width="7.5487" height="7.5487" fill="none" stroke="#999" stroke-width=".57841"/>
+   <rect x="12.162" y=".2892" width="7.5487" height="7.5487" fill="none" stroke="#999" stroke-width=".57841"/>
+   <rect x="12.162" y="12.162" width="7.5487" height="7.5487" fill="none" stroke="#999" stroke-width=".57841"/>
+   <rect x=".2892" y="12.162" width="7.5487" height="7.5487" fill="none" stroke="#999" stroke-width=".57841"/>
+  </clipPath>
+ </defs>
+ <!-- ImageGlass icons http://www.imageglass.org -->
+ <g>
+  <title>background</title>
+  <rect id="canvas_background" x="-1" y="-1" width="22" height="22" fill="none"/>
+  <g id="canvasGrid" display="none">
+   <rect width="100%" height="100%" fill="url(#gridpattern)" stroke-width="0"/>
+  </g>
+ </g>
+ <g>
+  <title>Layer 1</title>
+  <rect x="5.7488" y="6.8561" width="8.5024" height="6.2879" fill="#dedede"/>
+  <rect x="2.1919" y="2.1919" width="15.616" height="15.616" clip-path="url(#clipPath2753)" fill="none" stroke="#dedede" stroke-width=".7"/>
+ </g>
+</svg>

--- a/Setup/Assets/Themes/Kobe/igtheme.xml
+++ b/Setup/Assets/Themes/Kobe/igtheme.xml
@@ -30,6 +30,7 @@
         zoomtofit="ScaleToFit.svg"
         scaletofill="ScaleToFill.svg"
         scaletofit="ActualSize.svg"
+        scaletofitalready="ActualSizeAlready.svg"
         scaletowidth="ScaleToWidth.svg"
         scaletoheight="ScaleToHeight.svg"
         autosizewindow="AdjustWindowSize.svg"

--- a/Source/Components/ImageGlass.UI/Theme/Theme.cs
+++ b/Source/Components/ImageGlass.UI/Theme/Theme.cs
@@ -300,6 +300,7 @@ namespace ImageGlass.UI {
             ToolbarIcons.ZoomOut.Refresh(iconHeight);
             ToolbarIcons.ScaleToFit.Refresh(iconHeight);
             ToolbarIcons.ActualSize.Refresh(iconHeight);
+            ToolbarIcons.ActualSizeAlready.Refresh(iconHeight);
             ToolbarIcons.LockRatio.Refresh(iconHeight);
             ToolbarIcons.AutoZoom.Refresh(iconHeight);
             ToolbarIcons.ScaleToWidth.Refresh(iconHeight);
@@ -537,6 +538,7 @@ namespace ImageGlass.UI {
             ToolbarIcons.ZoomOut = LoadThemeImage(dir, n, "zoomout", iconHeight);
             ToolbarIcons.ScaleToFit = LoadThemeImage(dir, n, "zoomtofit", iconHeight);
             ToolbarIcons.ActualSize = LoadThemeImage(dir, n, "scaletofit", iconHeight);
+            ToolbarIcons.ActualSizeAlready = LoadThemeImage(dir, n, "scaletofitalready", iconHeight);
             ToolbarIcons.LockRatio = LoadThemeImage(dir, n, "zoomlock", iconHeight);
             ToolbarIcons.AutoZoom = LoadThemeImage(dir, n, "autozoom", iconHeight);
             ToolbarIcons.ScaleToWidth = LoadThemeImage(dir, n, "scaletowidth", iconHeight);
@@ -653,6 +655,7 @@ namespace ImageGlass.UI {
             n.SetAttribute("zoomlock", Path.GetFileName(ToolbarIcons.LockRatio.Filename));
             n.SetAttribute("autozoom", Path.GetFileName(ToolbarIcons.AutoZoom.Filename));
             n.SetAttribute("scaletofit", Path.GetFileName(ToolbarIcons.ActualSize.Filename));
+            n.SetAttribute("scaletofitalready", Path.GetFileName(ToolbarIcons.ActualSizeAlready.Filename));
             n.SetAttribute("scaletowidth", Path.GetFileName(ToolbarIcons.ScaleToWidth.Filename));
             n.SetAttribute("scaletoheight", Path.GetFileName(ToolbarIcons.ScaleToHeight.Filename));
             n.SetAttribute("scaletofill", Path.GetFileName(ToolbarIcons.ScaleToFill.Filename));

--- a/Source/Components/ImageGlass.UI/Theme/ThemeIconCollection.cs
+++ b/Source/Components/ImageGlass.UI/Theme/ThemeIconCollection.cs
@@ -21,6 +21,7 @@ namespace ImageGlass.UI {
     public class ThemeIconCollection {
         public ThemeImage About { get; set; } = new();
         public ThemeImage ActualSize { get; set; } = new();
+        public ThemeImage ActualSizeAlready { get; set; } = new();
         public ThemeImage AdjustWindowSize { get; set; } = new();
         public ThemeImage Checkerboard { get; set; } = new();
         public ThemeImage Convert { get; set; } = new();

--- a/Source/ImageGlass/frmMain.cs
+++ b/Source/ImageGlass/frmMain.cs
@@ -135,6 +135,8 @@ namespace ImageGlass {
         // File system watcher
         private FileWatcherEx.FileWatcherEx _fileWatcher = new();
 
+        // Dual icon button handlers
+        private DualIconButton _actualSizeButton;
 
         #endregion
 
@@ -2719,7 +2721,8 @@ namespace ImageGlass {
             btnZoomIn.Image = th.ToolbarIcons.ZoomIn.Image;
             btnZoomOut.Image = th.ToolbarIcons.ZoomOut.Image;
             btnScaleToFit.Image = th.ToolbarIcons.ScaleToFit.Image;
-            btnActualSize.Image = th.ToolbarIcons.ActualSize.Image;
+            _actualSizeButton = new DualIconButton(btnActualSize, th.ToolbarIcons.ActualSize.Image, th.ToolbarIcons.ActualSizeAlready.Image);
+            _actualSizeButton.setImage(picMain.IsActualSize);
             btnZoomLock.Image = th.ToolbarIcons.LockRatio.Image;
             btnAutoZoom.Image = th.ToolbarIcons.AutoZoom.Image;
             btnScaletoWidth.Image = th.ToolbarIcons.ScaleToWidth.Image;
@@ -3255,6 +3258,9 @@ namespace ImageGlass {
 
             // Trigger Mouse Wheel event
             picMain.MouseWheel += picMain_MouseWheel;
+
+            // Zoom level change event
+            picMain.ZoomChanged += picMain_ZoomChanged;
 
             // Try to use a faster image clock for animating GIFs
             CheckAnimationClock(true);
@@ -3835,6 +3841,11 @@ namespace ImageGlass {
 
             // draw navigation regions
             PaintNavigationRegions(e);
+        }
+
+        private void picMain_ZoomChanged(object sender, EventArgs e) {
+            // If zoom level is actual size, use alternate icon for actual size button (if defined)
+            _actualSizeButton.setImage(picMain.IsActualSize);
         }
 
         #region File System Watcher events
@@ -5880,6 +5891,26 @@ namespace ImageGlass {
 
 
         #endregion
+    }
+
+
+    /// <summary>
+    /// DualIconButton manages a button that can have two possible images
+    /// </summary>
+    class DualIconButton {
+        public ToolStripButton Button;
+        public Image MainImage;
+        public Image AltImage;
+
+        public DualIconButton(ToolStripButton toolStripButton, Image mainImage = null, Image altImage = null) {
+            this.Button = toolStripButton;
+            this.MainImage = mainImage;
+            this.AltImage = altImage;
+            setImage();
+        }
+        public void setImage(bool useAltImage = false) {
+            Button.Image = useAltImage && AltImage != null ? AltImage : MainImage;
+        }
     }
 
 }


### PR DESCRIPTION
This is an alternative approach to https://github.com/d2phap/ImageGlass/pull/1615.

This change adds an optional ActualSizeAlready icon to theme. If defined, the actual size button will use this alternative icon when image is already actual size. (Open to alternate name suggestions.)

The contrib did not state policy on icons, so I tried to create a rough functional pair for actual size from scratch, but certainly could be changed out for better ones. I'm not very skilled with SVG tools. I could remove the icon changes and defer to a custom theme as well. As long as the code is there, anyone could override via theme.

On a side note, I debated if the actual size button should re-apply the current zoom mode when already actual size, but was not sure if the button was intended purely to apply actual size or if toggling made more sense. I figured I would leave function alone for now, but if asked I could give it a toggle style behavior between actual size and back to current zoom mode. The actual size function seems more like a snap to zoom level as opposed to a zoom mode, so trying not overlap or confuse with zoom modes. It kind of belongs more with the likes of zoom in/out functions rather than zoom modes.