### PR TITLE
Update default interpolation mode.

### DIFF
--- a/Source/Components/ImageGlass.Settings/Config.cs
+++ b/Source/Components/ImageGlass.Settings/Config.cs
@@ -617,12 +617,12 @@ public static class Config
     /// <summary>
     /// Gets, sets the interpolation mode to render the viewing image when the zoom factor is <c>less than or equals 100%</c>.
     /// </summary>
-    public static ImageInterpolation ImageInterpolationScaleDown { get; set; } = ImageInterpolation.MultiSampleLinear;
+    public static ImageInterpolation ImageInterpolationScaleDown { get; set; } = ImageInterpolation.Linear;
 
     /// <summary>
     /// Gets, sets the interpolation mode to render the viewing image when the zoom factor is <c>greater than 100%</c>.
     /// </summary>
-    public static ImageInterpolation ImageInterpolationScaleUp { get; set; } = ImageInterpolation.NearestNeighbor;
+    public static ImageInterpolation ImageInterpolationScaleUp { get; set; } = ImageInterpolation.HighQualityBicubic;
 
     /// <summary>
     /// Gets, sets value indicates what happens after clicking Edit menu


### PR DESCRIPTION
Closes #1716
Closes  #1701

For images that are upscaled, the interpolation mode should be at a higher quality. Since we now use GPU, we can set the max to **High Quality Bicubic** as the default.
This pull request changes **When zoom > 100%** to **High quality bicubic**.

For images that are downscaled, there is less need for high-quality interpolation since the details are being lost due to the downscale, I set it to **Nearest Neighbor** but **Linear** will also be an appropriate option.