### PR TITLE
Minor cleanups and optimizations

### DIFF
--- a/Source/Components/ImageGlass.Base/BHelper/ThemeUtils.cs
+++ b/Source/Components/ImageGlass.Base/BHelper/ThemeUtils.cs
@@ -76,17 +76,17 @@ public partial class BHelper
             if (hex.Length == 8)
             {
                 // #RRGGBBAA
-                red = byte.Parse(hex.Substring(0, 2), NumberStyles.AllowHexSpecifier);
-                green = byte.Parse(hex.Substring(2, 2), NumberStyles.AllowHexSpecifier);
-                blue = byte.Parse(hex.Substring(4, 2), NumberStyles.AllowHexSpecifier);
-                alpha = byte.Parse(hex.Substring(6, 2), NumberStyles.AllowHexSpecifier);
+                red = byte.Parse(hex.AsSpan(0, 2), NumberStyles.AllowHexSpecifier);
+                green = byte.Parse(hex.AsSpan(2, 2), NumberStyles.AllowHexSpecifier);
+                blue = byte.Parse(hex.AsSpan(4, 2), NumberStyles.AllowHexSpecifier);
+                alpha = byte.Parse(hex.AsSpan(6, 2), NumberStyles.AllowHexSpecifier);
             }
             else if (hex.Length == 6)
             {
                 // #RRGGBB
-                red = byte.Parse(hex.Substring(0, 2), NumberStyles.AllowHexSpecifier);
-                green = byte.Parse(hex.Substring(2, 2), NumberStyles.AllowHexSpecifier);
-                blue = byte.Parse(hex.Substring(4, 2), NumberStyles.AllowHexSpecifier);
+                red = byte.Parse(hex.AsSpan(0, 2), NumberStyles.AllowHexSpecifier);
+                green = byte.Parse(hex.AsSpan(2, 2), NumberStyles.AllowHexSpecifier);
+                blue = byte.Parse(hex.AsSpan(4, 2), NumberStyles.AllowHexSpecifier);
             }
             else if (hex.Length == 4)
             {

--- a/Source/Components/ImageGlass.Base/Cache/DiskCache.cs
+++ b/Source/Components/ImageGlass.Base/Cache/DiskCache.cs
@@ -235,10 +235,9 @@ public class DiskCache
     /// <returns>Item key.</returns>
     private static string MakeKey(string key)
     {
-        using var md5 = MD5.Create();
-        var hash = md5.ComputeHash(Encoding.ASCII.GetBytes(key));
+        var hash = MD5.HashData(Encoding.ASCII.GetBytes(key));
 
-        return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 
     /// <summary>

--- a/Source/Components/ImageGlass.Gallery/Extractor/GDIMetadataExtractor.cs
+++ b/Source/Components/ImageGlass.Gallery/Extractor/GDIMetadataExtractor.cs
@@ -71,7 +71,7 @@ public partial class GDIExtractor : IExtractor
         if (value == null || value.Length == 0)
             return string.Empty;
 
-        var str = Encoding.ASCII.GetString(value).Trim(new char[] { '\0' });
+        var str = Encoding.ASCII.GetString(value).Trim('\0');
 
         return str;
     }

--- a/Source/igcmd/Tools/FrmSlideshow.cs
+++ b/Source/igcmd/Tools/FrmSlideshow.cs
@@ -1129,8 +1129,7 @@ public partial class FrmSlideshow : ThemedForm
     {
         var intervalTo = Config.UseRandomIntervalForSlideshow ? Config.SlideshowIntervalTo : Config.SlideshowInterval;
 
-        var ran = new Random();
-        var interval = (float)(ran.NextDouble() * (intervalTo - Config.SlideshowInterval) + Config.SlideshowInterval);
+        var interval = (Random.Shared.NextSingle() * (intervalTo - Config.SlideshowInterval) + Config.SlideshowInterval);
 
         return interval;
     }


### PR DESCRIPTION
- replace byte.Parse(string.Substring()) calls with byte.Parse(string.AsSpan())
- use static MD5.HashData instead of creating a MD5 instance
- use Convert.ToHexString() instead of BitConverter.ToString(hash).Replace("-", "")
- Remove unnecessary array allocation in a string.Trim() call
- use Random.Shared and Random.NextSingle()