### PR TITLE
#1904 Unable to minimize ImageGlass

### DIFF
--- a/Source/Components/ImageGlass.Settings/Forms/ToolForm.cs
+++ b/Source/Components/ImageGlass.Settings/Forms/ToolForm.cs
@@ -68,16 +68,20 @@ public partial class ToolForm : ThemedForm
 
     protected override bool ShowWithoutActivation => true;
 
+
     protected override CreateParams CreateParams
     {
         get
         {
-            CreateParams baseParams = base.CreateParams;
+            var cp = base.CreateParams;
 
             const int WS_EX_NOACTIVATE = 0x08000000;
-            baseParams.ExStyle |= WS_EX_NOACTIVATE;
+            const int WS_MINIMIZEBOX = 0x20000;
 
-            return baseParams;
+            cp.ExStyle |= WS_EX_NOACTIVATE;
+            cp.Style ^= WS_MINIMIZEBOX; // hide Minimize box
+
+            return cp;
         }
     }
 

--- a/Source/Components/ImageGlass.UI/Forms/ModernForm.cs
+++ b/Source/Components/ImageGlass.UI/Forms/ModernForm.cs
@@ -162,6 +162,27 @@ public partial class ModernForm : Form
     // Protected / virtual methods
     #region Protected / virtual methods
 
+    protected override CreateParams CreateParams
+    {
+        get
+        {
+            // ensure that when in full-screen or frameless mode we can still use the 
+            // Windows shortcut keys to minimize, and allow the taskbar icon to minimize
+            // the window.
+            // ref https://www.fluxbytes.com/csharp/minimize-a-form-without-border-using-the-taskbar/
+
+            const int WS_MINIMIZEBOX = 0x20000;
+            const int CS_DBLCLKS = 0x8;
+
+            var cp = base.CreateParams;
+            cp.Style |= WS_MINIMIZEBOX;
+            cp.ClassStyle |= CS_DBLCLKS;
+
+            return cp;
+        }
+    }
+
+
     protected override void WndProc(ref Message m)
     {
         // WM_SYSCOMMAND

--- a/Source/ImageGlass/FrmMain.cs
+++ b/Source/ImageGlass/FrmMain.cs
@@ -77,26 +77,6 @@ public partial class FrmMain : ThemedForm
         ApplyTheme(Config.Theme.Settings.IsDarkMode);
     }
 
-    protected override CreateParams CreateParams
-    {
-        get
-        {
-            // ensure that when in full-screen or frameless mode we can still use the 
-            // Windows shortcut keys to minimize, and allow the taskbar icon to minimize
-            // the window.
-
-            // ref https://www.fluxbytes.com/csharp/minimize-a-form-without-border-using-the-taskbar/
-
-            const int WS_MINIMIZEBOX = 0x20000;
-            const int CS_DBLCLKS = 0x8;
-
-            var cp = base.CreateParams;
-            cp.Style |= WS_MINIMIZEBOX;
-            cp.ClassStyle |= CS_DBLCLKS;
-
-            return cp;
-        }
-    }
 
     protected override void OnDpiChanged()
     {

--- a/Source/ImageGlass/FrmMain.cs
+++ b/Source/ImageGlass/FrmMain.cs
@@ -77,6 +77,26 @@ public partial class FrmMain : ThemedForm
         ApplyTheme(Config.Theme.Settings.IsDarkMode);
     }
 
+    protected override CreateParams CreateParams
+    {
+        get
+        {
+            // ensure that when in full-screen or frameless mode we can still use the 
+            // Windows shortcut keys to minimize, and allow the taskbar icon to minimize
+            // the window.
+
+            // ref https://www.fluxbytes.com/csharp/minimize-a-form-without-border-using-the-taskbar/
+
+            const int WS_MINIMIZEBOX = 0x20000;
+            const int CS_DBLCLKS = 0x8;
+
+            var cp = base.CreateParams;
+            cp.Style |= WS_MINIMIZEBOX;
+            cp.ClassStyle |= CS_DBLCLKS;
+
+            return cp;
+        }
+    }
 
     protected override void OnDpiChanged()
     {
@@ -440,7 +460,6 @@ public partial class FrmMain : ThemedForm
             _ = LoadImageListAsync(paths, currentFile ?? filePath);
         }
     }
-
 
     /// <summary>
     /// Load the images list.


### PR DESCRIPTION
#1904

Modifies params passed to CreateWindow to ensure that a "full screen" or "frameless" IG window can be minimized using the WIN+M and WIN+DOWN keys.
