### PR TITLE
allow dragging the window when in borderless mode and the toolbar is hidden

### DIFF
--- a/Source/Components/ImageGlass.Views/ViewerCanvas.cs
+++ b/Source/Components/ImageGlass.Views/ViewerCanvas.cs
@@ -115,8 +115,10 @@ public partial class ViewerCanvas : DXCanvas
 
     // Navigation buttons
     private bool _isNavLeftHovered = false;
+    public bool IsNavLeftHovered => _isNavLeftHovered;
     private bool _isNavLeftPressed = false;
     private bool _isNavRightHovered = false;
+    public bool IsNavRightHovered => _isNavRightHovered;
     private bool _isNavRightPressed = false;
     private bool _isNavVisible = false;
     private NavButtonDisplay _navDisplay = NavButtonDisplay.None;

--- a/Source/ImageGlass/FrmMain.Designer.cs
+++ b/Source/ImageGlass/FrmMain.Designer.cs
@@ -1129,6 +1129,7 @@ namespace ImageGlass
             PicMain.DragOver += PicMain_DragOver;
             PicMain.MouseClick += PicMain_MouseClick;
             PicMain.MouseDoubleClick += PicMain_MouseDoubleClick;
+            PicMain.MouseDown += PicMain_MouseDown;
             PicMain.MouseWheel += PicMain_MouseWheel;
             // 
             // Gallery

--- a/Source/ImageGlass/FrmMain.cs
+++ b/Source/ImageGlass/FrmMain.cs
@@ -28,6 +28,7 @@ using ImageGlass.Settings;
 using ImageGlass.UI;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using WicNet;
 
@@ -53,6 +54,14 @@ public partial class FrmMain : ThemedForm
     private bool _showGallery = true;
     private Rectangle _windowBound;
     private FormWindowState _windowState = FormWindowState.Normal;
+
+    // allow dragging the window when in borderless mode and the toolbar is hidden
+    [DllImport("user32.dll")]
+    private static extern bool ReleaseCapture();
+    [DllImport("user32.dll")]
+    private static extern int SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
+    private const int WM_NCLBUTTONDOWN = 0xA1;
+    private const int HTCAPTION = 0x2;
 
     public FrmMain() : base()
     {

--- a/Source/ImageGlass/FrmMain/FrmMain.PicMainEvents.cs
+++ b/Source/ImageGlass/FrmMain/FrmMain.PicMainEvents.cs
@@ -423,4 +423,17 @@ public partial class FrmMain
         this.OnKeyUp(e);
     }
 
+
+    private void PicMain_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (e.Button != MouseButtons.Left || FormBorderStyle != FormBorderStyle.None || Config.ShowToolbar)
+        {
+            return;
+        }
+        if (!PicMain.IsNavLeftHovered && !PicMain.IsNavRightHovered)
+        {
+            ReleaseCapture();
+            _ = SendMessage(Handle, WM_NCLBUTTONDOWN, HTCAPTION, 0);
+        }
+    }
 }


### PR DESCRIPTION
Allow dragging the window by dragging the ViewerCanvas when in borderless mode and with the toolbar hidden.  
To avoid affecting the triggering of events for NavLeft and NavRight, the `IsNavLeftHovered` and `IsNavRightHovered` properties were added and are checked in `PicMain_MouseDown`.  