### PR TITLE
Fix Windows 10 LTSC 2021 Compatibility

### DIFF
--- a/Source/ImageGlass/ImageGlass.csproj
+++ b/Source/ImageGlass/ImageGlass.csproj
@@ -9,6 +9,7 @@
         <Platforms>x64;ARM64</Platforms>
         <ApplicationIcon>icon256.ico</ApplicationIcon>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+        <CetCompat>false</CetCompat>
 
         <AssemblyTitle>ImageGlass</AssemblyTitle>
         <Description>A lightweight, versatile image viewer</Description>

--- a/Source/igcmd/igcmd.csproj
+++ b/Source/igcmd/igcmd.csproj
@@ -7,6 +7,7 @@
         <UseWindowsForms>true</UseWindowsForms>
         <ImplicitUsings>enable</ImplicitUsings>
         <Platforms>x64;ARM64</Platforms>
+        <CetCompat>false</CetCompat>
 
         <AssemblyTitle>Igcmd: Command-line utility for ImageGlass</AssemblyTitle>
         <Copyright>Copyright © 2010 - 2026 Duong Dieu Phap</Copyright>


### PR DESCRIPTION
Windows 10 LTSC 2021 and earlier Windows 10 builds do not support Control-flow Enforcement Technology (CET). Starting with .NET 9.0, CET compatibility is enabled by default, which causes ImageGlass to crash on these systems at startup.

This PR resolves the issue by explicitly disabling CET compatibility for ImageGlass.

ImageGlass is:
- Not security-critical
- Not exposed to untrusted native plugins or arbitrary code execution

For this application, CET provides minimal practical security benefit. Disabling CET:
- Restores compatibility with unsupported Windows versions
- Does not introduce instability
- Does not reduce system-wide security, as the change applies only to this process

Reference: 
https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support