### PR TITLE
Add option to auto-switch to sibling directory on navigation boundary

### DIFF
--- a/Setup/Assets/Language/Chinese Simplified.iglang.json
+++ b/Setup/Assets/Language/Chinese Simplified.iglang.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "_Metadata": {
     "Code": "zh-CN",
     "EnglishName": "Chinese (Simplified)",
@@ -499,6 +499,9 @@
     "FrmMain.MnuLayout": "布局",
     "_._Website": "网站",
     "FrmMain.MnuPasteImage": "粘贴图像",
-    "FrmSettings._ShowGalleryScrollbars": "显示相册滚动条"
+    "FrmSettings._ShowGalleryScrollbars": "显示相册滚动条",
+    "FrmSettings._EnableAutoSwitchSiblingDir": "当前目录图片加载完毕后自动切换到下/上一个目录",
+    "FrmMain._SwitchedToNextDirectory": "已切换到下一个目录：{0}",
+    "FrmMain._SwitchedToPrevDirectory": "已切换到上一个目录：{0}"
   }
 }

--- a/Source/Components/ImageGlass.Base/Language/IgLang.cs
+++ b/Source/Components/ImageGlass.Base/Language/IgLang.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ImageGlass Project - Image viewer for Windows
 Copyright (C) 2010 - 2026 DUONG DIEU PHAP
 Project homepage: https://imageglass.org
@@ -555,6 +555,8 @@ public class IgLang : IDictionary<string, string>
             { "FrmMain._OpenWith", "Open with {0}" }, //v9.0
             { "FrmMain._ReachedFirstImage", "Reached the first image" }, // v4.0
             { "FrmMain._ReachedLastLast", "Reached the last image" }, // v4.0
+            { "FrmMain._SwitchedToNextDirectory", "Switched to next folder: {0}" },
+            { "FrmMain._SwitchedToPrevDirectory", "Switched to previous folder: {0}" },
             { "FrmMain._ClipboardImage", "Clipboard image" }, //v9.0
 
             #endregion
@@ -648,6 +650,7 @@ public class IgLang : IDictionary<string, string>
             { "FrmSettings._ShouldGroupImagesByDirectory", "Group images by directory" },
             { "FrmSettings._ShouldLoadHiddenImages", "Load hidden images" },
             { "FrmSettings._EnableLoopBackNavigation", "Loop back to the first image when reaching the end of the image list" },
+            { "FrmSettings._EnableAutoSwitchSiblingDir", "Automatically switch to the next/previous sibling directory when reaching the end of the image list" },
             { "FrmSettings._ShowImagePreview", "Display image preview while it's being loaded" },
             { "FrmSettings._EnableImageAsyncLoading", "Enable image asynchronous loading" },
 

--- a/Source/Components/ImageGlass.Settings/Config.cs
+++ b/Source/Components/ImageGlass.Settings/Config.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ImageGlass Project - Image viewer for Windows
 Copyright (C) 2010 - 2026 DUONG DIEU PHAP
 Project homepage: https://imageglass.org
@@ -192,6 +192,13 @@ public static class Config
     /// Gets, sets value indicating that ImageGlass will loop back viewer to the first image when reaching the end of the list.
     /// </summary>
     public static bool EnableLoopBackNavigation { get; set; } = true;
+
+    /// <summary>
+    /// Gets, sets value indicating that ImageGlass will automatically switch
+    /// to the next or previous sibling directory when reaching the boundary
+    /// of the current image list.
+    /// </summary>
+    public static bool EnableAutoSwitchSiblingDir { get; set; } = false;
 
     /// <summary>
     /// Gets, sets value indicating that checker board is shown or not
@@ -708,6 +715,7 @@ public static class Config
         ShowFrameNavTool = items.GetValueEx(nameof(ShowFrameNavTool), ShowFrameNavTool);
         ShowAppIcon = items.GetValueEx(nameof(ShowAppIcon), ShowAppIcon);
         EnableLoopBackNavigation = items.GetValueEx(nameof(EnableLoopBackNavigation), EnableLoopBackNavigation);
+        EnableAutoSwitchSiblingDir = items.GetValueEx(nameof(EnableAutoSwitchSiblingDir), EnableAutoSwitchSiblingDir);
         ShowCheckerboard = items.GetValueEx(nameof(ShowCheckerboard), ShowCheckerboard);
         ShowCheckerboardOnlyImageRegion = items.GetValueEx(nameof(ShowCheckerboardOnlyImageRegion), ShowCheckerboardOnlyImageRegion);
         EnableMultiInstances = items.GetValueEx(nameof(EnableMultiInstances), EnableMultiInstances);
@@ -1080,6 +1088,7 @@ public static class Config
         _ = settings.TryAdd(nameof(ShowFrameNavTool), ShowFrameNavTool);
         _ = settings.TryAdd(nameof(ShowAppIcon), ShowAppIcon);
         _ = settings.TryAdd(nameof(EnableLoopBackNavigation), EnableLoopBackNavigation);
+        _ = settings.TryAdd(nameof(EnableAutoSwitchSiblingDir), EnableAutoSwitchSiblingDir);
         _ = settings.TryAdd(nameof(ShowCheckerboard), ShowCheckerboard);
         _ = settings.TryAdd(nameof(ShowCheckerboardOnlyImageRegion), ShowCheckerboardOnlyImageRegion);
         _ = settings.TryAdd(nameof(EnableMultiInstances), EnableMultiInstances);

--- a/Source/Components/ImageGlass.Settings/WebUI/FrmSettings.html
+++ b/Source/Components/ImageGlass.Settings/WebUI/FrmSettings.html
@@ -312,6 +312,12 @@
         </div>
         <div class="mb-2">
           <label class="ig-checkbox">
+            <input type="checkbox" name="EnableAutoSwitchSiblingDir" />
+            <div lang-text="FrmSettings._EnableAutoSwitchSiblingDir">[EnableAutoSwitchSiblingDir]</div>
+          </label>
+        </div>
+        <div class="mb-2">
+          <label class="ig-checkbox">
             <input type="checkbox" name="ShowImagePreview" />
             <div lang-text="FrmSettings._ShowImagePreview">[ShowImagePreview]</div>
           </label>

--- a/Source/ImageGlass/FrmMain.cs
+++ b/Source/ImageGlass/FrmMain.cs
@@ -790,7 +790,7 @@ public partial class FrmMain : ThemedForm
                                 _pendingSwitchDirMessage = string.Format(
                                     Config.Language[$"{Name}._SwitchedToNextDirectory"],
                                     Path.GetFileName(nextDir));
-                                PrepareLoading(nextDir, false);
+                                PrepareLoading(nextDir, true);
                                 return;
                             }
                         }
@@ -826,7 +826,7 @@ public partial class FrmMain : ThemedForm
                                     Config.Language[$"{Name}._SwitchedToPrevDirectory"],
                                     Path.GetFileName(prevDir));
                                 _pendingNavigateToLast = true;
-                                PrepareLoading(prevDir, false);
+                                PrepareLoading(prevDir, true);
                                 return;
                             }
                         }

--- a/Source/ImageGlass/FrmMain.cs
+++ b/Source/ImageGlass/FrmMain.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ImageGlass Project - Image viewer for Windows
 Copyright (C) 2010 - 2026 DUONG DIEU PHAP
 Project homepage: https://imageglass.org
@@ -43,6 +43,8 @@ public partial class FrmMain : ThemedForm
     private MovableForm? _movableForm;
     private FileFinder? _fileFinder = new();
     string? _inputFilePath;
+    private bool _pendingNavigateToLast;
+    private string? _pendingSwitchDirMessage;
 
 
     // variable to back up / restore window layout when changing window mode
@@ -440,6 +442,86 @@ public partial class FrmMain : ThemedForm
 
 
     /// <summary>
+    /// Gets the next or previous sibling directory relative to the current one.
+    /// </summary>
+    /// <param name="direction">+1 for next, -1 for previous</param>
+    /// <returns>Full path of the sibling directory, or <c>null</c> if none exists.</returns>
+    private static string? GetSiblingDirectory(int direction)
+    {
+        // prefer deriving directory from the current image path
+        string? currentDir = null;
+
+        if (Local.CurrentIndex >= 0 && Local.CurrentIndex < Local.Images.Length)
+        {
+            var imgPath = Local.Images.GetFilePath(Local.CurrentIndex);
+            if (!string.IsNullOrEmpty(imgPath))
+            {
+                currentDir = Path.GetDirectoryName(imgPath);
+            }
+        }
+
+        if (string.IsNullOrEmpty(currentDir))
+        {
+            currentDir = Local.InitialInputPath;
+        }
+
+        if (string.IsNullOrEmpty(currentDir)) return null;
+
+        // ensure we have a directory path, not a file path
+        if (File.Exists(currentDir))
+        {
+            currentDir = Path.GetDirectoryName(currentDir);
+            if (string.IsNullOrEmpty(currentDir)) return null;
+        }
+
+        var parentDir = Directory.GetParent(currentDir)?.FullName;
+        if (string.IsNullOrEmpty(parentDir)) return null;
+
+        try
+        {
+            var siblingDirs = Directory.GetDirectories(parentDir)
+                .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var currentIndex = siblingDirs.FindIndex(d =>
+                string.Equals(d, currentDir, StringComparison.OrdinalIgnoreCase));
+            if (currentIndex < 0) return null;
+
+            var nextIndex = currentIndex + direction;
+            while (nextIndex >= 0 && nextIndex < siblingDirs.Count)
+            {
+                if (DirectoryContainsImages(siblingDirs[nextIndex]))
+                    return siblingDirs[nextIndex];
+                nextIndex += direction;
+            }
+        }
+        catch (UnauthorizedAccessException) { }
+        catch (IOException) { }
+
+        return null;
+    }
+
+
+    /// <summary>
+    /// Checks if a directory contains at least one supported image file.
+    /// </summary>
+    private static bool DirectoryContainsImages(string dirPath)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(dirPath)
+                .Any(f =>
+                {
+                    var ext = Path.GetExtension(f).ToLowerInvariant();
+                    return ext.Length > 0 && Config.FileFormats.Contains(ext);
+                });
+        }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (IOException) { return false; }
+    }
+
+
+    /// <summary>
     /// Load the images list.
     /// </summary>
     /// <param name="inputPaths">The list of files to load</param>
@@ -700,6 +782,19 @@ public partial class FrmMain : ThemedForm
                             FilePath = oldImgPath,
                         }, nameof(Local.RaiseLastImageReachedEvent)));
 
+                        if (Config.EnableAutoSwitchSiblingDir)
+                        {
+                            var nextDir = GetSiblingDirectory(1);
+                            if (nextDir != null)
+                            {
+                                _pendingSwitchDirMessage = string.Format(
+                                    Config.Language[$"{Name}._SwitchedToNextDirectory"],
+                                    Path.GetFileName(nextDir));
+                                PrepareLoading(nextDir, false);
+                                return;
+                            }
+                        }
+
                         if (!Config.EnableLoopBackNavigation || Local.Images.Length == 1)
                         {
                             // if the image is not rendered yet
@@ -722,6 +817,19 @@ public partial class FrmMain : ThemedForm
                             FilePath = oldImgPath,
                         }, nameof(Local.RaiseFirstImageReachedEvent)));
 
+                        if (Config.EnableAutoSwitchSiblingDir)
+                        {
+                            var prevDir = GetSiblingDirectory(-1);
+                            if (prevDir != null)
+                            {
+                                _pendingSwitchDirMessage = string.Format(
+                                    Config.Language[$"{Name}._SwitchedToPrevDirectory"],
+                                    Path.GetFileName(prevDir));
+                                _pendingNavigateToLast = true;
+                                PrepareLoading(prevDir, false);
+                                return;
+                            }
+                        }
 
                         if (!Config.EnableLoopBackNavigation || Local.Images.Length == 1)
                         {
@@ -1134,6 +1242,12 @@ public partial class FrmMain : ThemedForm
         LoadImageInfo(ImageInfoUpdateTypes.Dimension | ImageInfoUpdateTypes.FrameCount);
 
 
+        if (_pendingSwitchDirMessage != null)
+        {
+            PicMain.ShowMessage(_pendingSwitchDirMessage, Config.InAppMessageDuration);
+            _pendingSwitchDirMessage = null;
+        }
+
         // Collect system garbage
         Local.GcCollect();
     }
@@ -1144,6 +1258,13 @@ public partial class FrmMain : ThemedForm
         if (!string.IsNullOrEmpty(e.InitFilePath))
         {
             UpdateCurrentIndex(e.InitFilePath);
+        }
+
+        if (_pendingNavigateToLast && Local.Images.Length > 0)
+        {
+            _pendingNavigateToLast = false;
+            Local.CurrentIndex = Local.Images.Length - 1;
+            _ = ViewNextCancellableAsync(0);
         }
 
         LoadImageInfo(ImageInfoUpdateTypes.ListCount);
@@ -1159,6 +1280,8 @@ public partial class FrmMain : ThemedForm
 
     private void HandleImage_FirstReached()
     {
+        if (Config.EnableAutoSwitchSiblingDir) return;
+
         if (!Config.EnableLoopBackNavigation || Local.Images.Length == 1)
         {
             PicMain.ShowMessage(Config.Language[$"{Name}._ReachedFirstImage"],
@@ -1169,6 +1292,8 @@ public partial class FrmMain : ThemedForm
 
     private void HandleImage_LastReached()
     {
+        if (Config.EnableAutoSwitchSiblingDir) return;
+
         if (!Config.EnableLoopBackNavigation || Local.Images.Length == 1)
         {
             PicMain.ShowMessage(Config.Language[$"{Name}._ReachedLastLast"],

--- a/Source/ImageGlass/Local.cs
+++ b/Source/ImageGlass/Local.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ImageGlass Project - Image viewer for Windows
 Copyright (C) 2010 - 2026 DUONG DIEU PHAP
 Project homepage: https://imageglass.org
@@ -890,6 +890,7 @@ public class Local
         if (Config.SetFromJson(dict, nameof(Config.ShouldLoadHiddenImages)).Done) { reloadImgList = true; }
 
         _ = Config.SetFromJson(dict, nameof(Config.EnableLoopBackNavigation));
+        _ = Config.SetFromJson(dict, nameof(Config.EnableAutoSwitchSiblingDir));
         _ = Config.SetFromJson(dict, nameof(Config.ShowImagePreview));
         _ = Config.SetFromJson(dict, nameof(Config.EnableImageAsyncLoading));
 


### PR DESCRIPTION
Currently, when reaching the last or first image in a directory, navigation either stops or loops back.
This PR adds a new optional setting EnableAutoSwitchSiblingDir (default off) that automatically switches to the next or previous sibling directory, allowing seamless browsing across folders.

When switching, a toast message is displayed showing the target folder name.
Navigating backward lands on the last image of the previous directory.
Sibling directories that contain no supported image files are skipped.

Chinese Simplified translations are also included.