### PR TITLE
Added DPI to image imformation tags

### DIFF
--- a/Source/Components/ImageGlass.Base/ImageInfo/ImageInfo.cs
+++ b/Source/Components/ImageGlass.Base/ImageInfo/ImageInfo.cs
@@ -39,6 +39,7 @@ public static class ImageInfo
 
     public static string? DateTimeAuto { get; set; } = null;
     public static string? ColorSpace { get; set; } = null;
+    public static string? DPI { get; set; } = null;
 
 
     public static bool IsNull => AppName == null
@@ -56,7 +57,9 @@ public static class ImageInfo
         && ExifDateTimeOriginal == null
 
         && ExifRating == null
-        && ColorSpace == null;
+        && ColorSpace == null
+
+        && DPI == null;
 
 
     /// <summary>
@@ -80,7 +83,8 @@ public static class ImageInfo
                 ExifDateTime =
                 ExifDateTimeOriginal =
                 DateTimeAuto =
-                ColorSpace = null;
+                ColorSpace = 
+                DPI = null;
 
             if (!string.IsNullOrEmpty(clipboardImageText))
             {

--- a/Source/Components/ImageGlass.Base/ImageInfo/ImageInfoUpdateTypes.cs
+++ b/Source/Components/ImageGlass.Base/ImageInfo/ImageInfoUpdateTypes.cs
@@ -41,4 +41,6 @@ public enum ImageInfoUpdateTypes
 
     ExifRating = 1 << 13,
     ColorSpace = 1 << 14,
+    
+    DPI = 1 << 15
 }

--- a/Source/Components/ImageGlass.Base/Photoing/Codecs/IgMetadata.cs
+++ b/Source/Components/ImageGlass.Base/Photoing/Codecs/IgMetadata.cs
@@ -52,6 +52,10 @@ public class IgMetadata
     public uint RenderedWidth { get; set; } = 0;
     public uint RenderedHeight { get; set; } = 0;
 
+    // DPI
+    public float DpiX { get; set; } = 0;
+    public float DpiY { get; set; } = 0;
+
     /// <summary>
     /// Gets the frame index of this metadata.
     /// </summary>

--- a/Source/Components/ImageGlass.Base/Photoing/Codecs/PhotoCodec.cs
+++ b/Source/Components/ImageGlass.Base/Photoing/Codecs/PhotoCodec.cs
@@ -115,6 +115,11 @@ public static class PhotoCodec
                     meta.RenderedHeight = imgM.Height;
                 }
 
+                // DPI
+                var density = imgM.Density;
+                // Convert units to inch
+                meta.DpiX = (float)density.X * 2.54f;
+                meta.DpiY = (float)density.Y * 2.54f;
 
                 // image color
                 meta.HasAlpha = imgC.Any(i => i.HasAlpha);

--- a/Source/ImageGlass/FrmMain.cs
+++ b/Source/ImageGlass/FrmMain.cs
@@ -1567,8 +1567,22 @@ public partial class FrmMain : ThemedForm
                 }
             }
 
+            // DPI
+            if (updateAll || types!.Value.HasFlag(ImageInfoUpdateTypes.DPI))
+            {
+                if (Config.ImageInfoTags.Contains(nameof(ImageInfo.DPI))
+                    && Local.Metadata != null
+                    && Local.Metadata.DpiX > 0
+                    && Local.Metadata.DpiY > 0)
+                {
+                    ImageInfo.DPI = $"{Local.Metadata.DpiX:n0}×{Local.Metadata.DpiY:n0} DPI";
+                }
+                else
+                {
+                    ImageInfo.DPI = string.Empty;
+                }
+            }
         }
-
 
         Text = ImageInfo.ToString(Config.ImageInfoTags, Local.ClipboardImage != null, clipboardImageText);
     }

--- a/Source/igcmd/Tools/FrmSlideshow.cs
+++ b/Source/igcmd/Tools/FrmSlideshow.cs
@@ -1355,7 +1355,21 @@ public partial class FrmSlideshow : ThemedForm
             }
         }
 
-
+        // DPI
+        if (updateAll || types!.Value.HasFlag(ImageInfoUpdateTypes.DPI))
+        {
+            if (Config.ImageInfoTags.Contains(nameof(ImageInfo.DPI))
+                && _currentMetadata != null
+                && _currentMetadata.DpiX > 0
+                && _currentMetadata.DpiY > 0)
+            {
+                ImageInfo.DPI = $"{_currentMetadata.DpiX:n0}×{_currentMetadata.DpiY:n0} DPI";
+            }
+            else
+            {
+                ImageInfo.DPI = string.Empty;
+            }
+        }
 
         Text = ImageInfo.ToString(Config.ImageInfoTags, false);
     }


### PR DESCRIPTION
I added support for DPI in the image information tags in the general tab in setting.
So now when selected it shows the DPI of the image in the title bar.

Closes #2263