### PR TITLE
Load mipmap tiles asynchronously

### DIFF
--- a/source/ImageGlass.Lib/UI/Viewer/Renderer/MipmapTileCache.cs
+++ b/source/ImageGlass.Lib/UI/Viewer/Renderer/MipmapTileCache.cs
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+using Avalonia.Threading;
 using ImageGlass.Common.Extensions;
 using ImageGlass.Common.Photoing;
 using ImageGlass.Common.Types;
@@ -23,13 +24,14 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ImageGlass.UI.Viewer;
 
 
 /// <summary>
 /// A tiled mipmap cache for rendering large images efficiently.
-/// Tiles are extracted on-demand from the source image at the requested mip level
+/// A downscaled proxy is shown while tiles are extracted on-demand at the requested mip level
 /// and cached with LRU eviction to bound memory usage.
 /// <para>
 /// At each mip level, a tile covers <c>TILE_SIZE &lt;&lt; mipLevel</c> source pixels
@@ -43,6 +45,7 @@ internal sealed class MipmapTileCache : PhDisposable
     public const int TILE_SIZE = 512;
     private const int MAX_CACHED_TILES = 100;
     private const int MAX_MIP_LEVEL = 6;
+    private const int PROXY_MAX_DIMENSION = 4096;
 
     /// <summary>
     /// Minimum total pixels to benefit from tiling.
@@ -60,7 +63,7 @@ internal sealed class MipmapTileCache : PhDisposable
     /// Maps (tileX, tileY, mipLevel) to cached SKImage tiles.
     /// Each tile is a 512×512 image extracted from the source at the given mip level.
     /// </summary>
-    private readonly Dictionary<(int x, int y, int level), SKImage> _tiles = [];
+    private readonly Dictionary<(int x, int y, int level), SKImageRef> _tiles = [];
 
     /// <summary>
     /// Maps (tileX, tileY, mipLevel) to LinkedListNode for O(1) LRU promotion.
@@ -74,6 +77,12 @@ internal sealed class MipmapTileCache : PhDisposable
     /// When cache exceeds MAX_CACHED_TILES, tiles are evicted from the front.
     /// </summary>
     private readonly LinkedList<(int x, int y, int level)> _lruList = new();
+
+    /// <summary>
+    /// Pending tiles are processed newest-first so the current viewport is prioritized.
+    /// </summary>
+    private readonly Stack<(int x, int y, int level)> _tileQueue = new();
+    private readonly HashSet<(int x, int y, int level)> _pendingTiles = [];
 
     /// <summary>
     /// Reference to the full-resolution source image (SKImageRef).
@@ -92,11 +101,16 @@ internal sealed class MipmapTileCache : PhDisposable
     /// </summary>
     private readonly SKColorSpace? _colorSpace;
 
+    private readonly Action _tileReady;
+
     /// <summary>
     /// Maximum number of tiles to cache, scaled down for high-bit-depth formats
     /// to stay within a constant memory budget.
     /// </summary>
     private readonly int _maxCachedTiles;
+    private SKImageRef? _proxy;
+    private bool _workerRunning;
+    private bool _isStopping;
 
 
     /// <summary>
@@ -111,7 +125,7 @@ internal sealed class MipmapTileCache : PhDisposable
 
 
     private MipmapTileCache(SKImageRef sourceRef, int width, int height,
-        SKColorType colorType, SKColorSpace? colorSpace)
+        SKColorType colorType, SKColorSpace? colorSpace, Action tileReady)
     {
         _sourceRef = sourceRef;
         _sourceRef.KeepAlive();
@@ -119,6 +133,7 @@ internal sealed class MipmapTileCache : PhDisposable
         SourceHeight = height;
         _colorType = colorType;
         _colorSpace = colorSpace;
+        _tileReady = tileReady;
 
         // Scale max tiles inversely with bytes-per-pixel to keep a constant memory budget.
         // Budget baseline: MAX_CACHED_TILES tiles of Rgba8888 (4 bpp).
@@ -136,7 +151,7 @@ internal sealed class MipmapTileCache : PhDisposable
     /// Creates a tile cache for the given source image, or returns <c>null</c>
     /// if the image is too small to benefit from tiling.
     /// </summary>
-    public static MipmapTileCache? Create(SKImageRef? sourceRef)
+    public static MipmapTileCache? Create(SKImageRef? sourceRef, Action tileReady)
     {
         var img = sourceRef?.Image;
         if (img is null || img.IsDisposed()) return null;
@@ -144,8 +159,10 @@ internal sealed class MipmapTileCache : PhDisposable
         var pixels = (long)img.Width * img.Height;
         if (pixels < MIN_PIXELS_FOR_TILING) return null;
 
-        return new MipmapTileCache(sourceRef!, img.Width, img.Height,
-            img.ColorType, img.ColorSpace);
+        var cache = new MipmapTileCache(sourceRef!, img.Width, img.Height,
+            img.ColorType, img.ColorSpace, tileReady);
+        _ = Task.Run(cache.GenerateProxy);
+        return cache;
     }
 
 
@@ -179,17 +196,33 @@ internal sealed class MipmapTileCache : PhDisposable
     #region Instance Methods
 
     /// <summary>
-    /// Gets a tile image, returning a cached version or extracting a new one.
-    /// The returned <see cref="SKImage"/> is owned by the cache — do NOT dispose it.
+    /// Acquires the downscaled full-image proxy, if it is ready.
     /// </summary>
-    public SKImage? GetTile(int tileX, int tileY, int mipLevel)
+    public SKImageRef.ImageLease? AcquireProxy()
+    {
+        if (IsDisposed) return null;
+
+        lock (_lock)
+        {
+            return _isStopping ? null : _proxy?.Acquire();
+        }
+    }
+
+
+    /// <summary>
+    /// Acquires the requested tile, or queues it for background generation.
+    /// </summary>
+    public SKImageRef.ImageLease? GetOrQueueTile(int tileX, int tileY, int mipLevel)
     {
         if (IsDisposed) return null;
 
         var key = (tileX, tileY, mipLevel);
+        var startWorker = false;
 
         lock (_lock)
         {
+            if (_isStopping) return null;
+
             if (_tiles.TryGetValue(key, out var cached))
             {
                 // O(1) LRU promotion
@@ -198,55 +231,115 @@ internal sealed class MipmapTileCache : PhDisposable
                     _lruList.Remove(node);
                     _lruList.AddLast(node);
                 }
-                return cached;
+                return cached.Acquire();
             }
+
+            if (_pendingTiles.Add(key))
+            {
+                _tileQueue.Push(key);
+            }
+
+            startWorker = !_workerRunning;
+            _workerRunning = true;
         }
 
-        // extract tile outside lock (heavy work, SKImage reads are thread-safe)
-        SKImage? tile;
+        if (startWorker) _ = Task.Run(ProcessPendingTiles);
+        return null;
+    }
+
+
+    private void ProcessPendingTiles()
+    {
+        while (true)
+        {
+            (int x, int y, int level) key;
+
+            lock (_lock)
+            {
+                if (_isStopping || _tileQueue.Count == 0)
+                {
+                    _workerRunning = false;
+                    return;
+                }
+
+                key = _tileQueue.Pop();
+            }
+
+            SKImage? tile = null;
+            try
+            {
+                tile = ExtractTile(key.x, key.y, key.level);
+            }
+            catch { }
+
+            lock (_lock)
+            {
+                _pendingTiles.Remove(key);
+
+                if (_isStopping || tile is null)
+                {
+                    tile?.Dispose();
+                    continue;
+                }
+
+                _tiles[key] = new SKImageRef(tile);
+                _nodeMap[key] = _lruList.AddLast(key);
+
+                // LRU eviction
+                while (_tiles.Count > _maxCachedTiles && _lruList.First is not null)
+                {
+                    var oldest = _lruList.First.Value;
+                    _lruList.RemoveFirst();
+                    _nodeMap.Remove(oldest);
+
+                    if (_tiles.Remove(oldest, out var image))
+                    {
+                        image.RequestDispose();
+                    }
+                }
+            }
+
+            RequestRedraw();
+        }
+    }
+
+
+    private void GenerateProxy()
+    {
+        if (IsDisposed) return;
+
+        var scale = (double)PROXY_MAX_DIMENSION / Math.Max(SourceWidth, SourceHeight);
+        SKImage? proxy = null;
+
         try
         {
-            tile = ExtractTile(tileX, tileY, mipLevel);
+            proxy = ExtractFromSource(0, 0, SourceWidth, SourceHeight,
+                Math.Max(1, (int)Math.Round(SourceWidth * scale)),
+                Math.Max(1, (int)Math.Round(SourceHeight * scale)));
         }
-        catch
-        {
-            return null;
-        }
-
-        if (tile is null) return null;
+        catch { }
 
         lock (_lock)
         {
-            // double-check: another thread may have inserted while we were extracting
-            if (_tiles.TryGetValue(key, out var existing))
+            if (_isStopping || proxy is null)
             {
-                tile.Dispose();
-                if (_nodeMap.TryGetValue(key, out var existingNode))
-                {
-                    _lruList.Remove(existingNode);
-                    _lruList.AddLast(existingNode);
-                }
-                return existing;
+                proxy?.Dispose();
+                return;
             }
 
-            _tiles[key] = tile;
-            _nodeMap[key] = _lruList.AddLast(key);
-
-            // LRU eviction
-            while (_tiles.Count > _maxCachedTiles && _lruList.First is not null)
-            {
-                var oldest = _lruList.First.Value;
-                _lruList.RemoveFirst();
-                _nodeMap.Remove(oldest);
-
-                if (_tiles.Remove(oldest, out var image))
-                {
-                    image.Dispose();
-                }
-            }
+            _proxy = new SKImageRef(proxy);
         }
 
-        return tile;
+        RequestRedraw();
+    }
+
+
+    private void RequestRedraw()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (!IsDisposed) _tileReady();
+        }, DispatcherPriority.Render);
     }
 
 
@@ -311,10 +404,15 @@ internal sealed class MipmapTileCache : PhDisposable
 
         lock (_lock)
         {
-            foreach (var tile in _tiles.Values) tile.Dispose();
+            _isStopping = true;
+
+            _proxy?.RequestDispose();
+            foreach (var tile in _tiles.Values) tile.RequestDispose();
             _tiles.Clear();
             _lruList.Clear();
             _nodeMap.Clear();
+            _pendingTiles.Clear();
+            _tileQueue.Clear();
         }
 
         _sourceRef.RequestDispose();

--- a/source/ImageGlass.Lib/UI/Viewer/Renderer/PhotoRenderer.cs
+++ b/source/ImageGlass.Lib/UI/Viewer/Renderer/PhotoRenderer.cs
@@ -212,14 +212,16 @@ public partial class PhotoRenderer : ICustomDrawOperation
                     _isFirstDraw = false;
                     Dispatcher.UIThread.Post(() => _onDrawFirstTime(imageRender), DispatcherPriority.Send);
                 }
-                else if (_tileCache is not null)
+                else if (_tileCache?.AcquireProxy() is { } proxyLease)
                 {
-                    // tiled rendering for large images
-                    RenderTiled(lease.SkCanvas);
+                    using (proxyLease)
+                    {
+                        RenderTiled(lease.SkCanvas, proxyLease.Image);
+                    }
                 }
                 else
                 {
-                    // direct rendering for small / animated images
+                    // direct rendering for small / animated images, and until the proxy is ready
                     imageLease = _imgRender?.Acquire() ?? _imgSource?.Acquire();
                     imageRender = imageLease?.Image;
 
@@ -248,9 +250,9 @@ public partial class PhotoRenderer : ICustomDrawOperation
 
 
     /// <summary>
-    /// Renders visible tiles from the tile cache.
+    /// Renders the proxy image followed by available detail tiles.
     /// </summary>
-    private void RenderTiled(SKCanvas canvas)
+    private void RenderTiled(SKCanvas canvas, SKImage proxy)
     {
         var tileCache = _tileCache!;
         var mipLevel = MipmapTileCache.GetMipLevel(_zoomFactor);
@@ -271,13 +273,19 @@ public partial class PhotoRenderer : ICustomDrawOperation
 
         canvas.Save();
 
+        var proxyScaleX = (float)proxy.Width / tileCache.SourceWidth;
+        var proxyScaleY = (float)proxy.Height / tileCache.SourceHeight;
+        var proxySrc = new SKRect(
+            _srcRect.Left * proxyScaleX,
+            _srcRect.Top * proxyScaleY,
+            _srcRect.Right * proxyScaleX,
+            _srcRect.Bottom * proxyScaleY);
+        canvas.DrawImage(proxy, proxySrc, _destRect, _samplingOptions);
+
         for (var ty = tileStartY; ty < tileEndY; ty++)
         {
             for (var tx = tileStartX; tx < tileEndX; tx++)
             {
-                var imgTile = tileCache.GetTile(tx, ty, mipLevel);
-                if (imgTile.IsDisposed()) continue;
-
                 // tile bounds in original image coordinates
                 float tileSrcLeft = tx * sourceTileSize;
                 float tileSrcTop = ty * sourceTileSize;
@@ -291,6 +299,10 @@ public partial class PhotoRenderer : ICustomDrawOperation
                 var clippedBottom = Math.Min(tileSrcTop + tileSrcH, _srcRect.Bottom);
 
                 if (clippedLeft >= clippedRight || clippedTop >= clippedBottom) continue;
+
+                using var tileLease = tileCache.GetOrQueueTile(tx, ty, mipLevel);
+                var imgTile = tileLease?.Image;
+                if (imgTile.IsDisposed()) continue;
 
                 // map clipped region to tile bitmap coordinates
                 var tileBitmapSrc = new SKRect(

--- a/source/ImageGlass.Lib/UI/Viewer/ViewerControl_Render.cs
+++ b/source/ImageGlass.Lib/UI/Viewer/ViewerControl_Render.cs
@@ -457,7 +457,7 @@ public partial class ViewerControl
         if (_animator is not null) return;
 
         // use the processed (color-managed) image if available, otherwise the source
-        _mipmapCache = MipmapTileCache.Create(_imgRender ?? _imgSource);
+        _mipmapCache = MipmapTileCache.Create(_imgRender ?? _imgSource, InvalidateVisual);
 
         PhotoTrace.Mark("render:mipmap-cache", Photo?.FilePath,
             _mipmapCache is null ? "not created (image too small)" : "created");


### PR DESCRIPTION
### 🟢 Summary
Loads mipmap tiles asynchronously using a single background worker so that zooming and panning remain smooth. A downscaled proxy (maximum dimension of 4096 px) is displayed beneath tiles that haven’t loaded yet.

I also tried scheduling each tile as a separate task, but it didn't noticeably improve performance.

### 🟢 Contributor License Agreement (CLA)
By submitting this pull request, I confirm that:
- [x] I agree to the [**ImageGlass Contributor License Agreement (CLA)**](../CLA.md)
