### PR TITLE
Reduce gallery I/O and improve responsiveness

### DIFF
--- a/source/ImageGlass.Lib/Common/Photoing/Manager/PhotoManager_Caching.cs
+++ b/source/ImageGlass.Lib/Common/Photoing/Manager/PhotoManager_Caching.cs
@@ -249,7 +249,7 @@ public partial class PhotoManager
                     // check dimension constraint (requires metadata)
                     if (maxDimension > 0)
                     {
-                        await photo.LoadMetadataAsync(useCache: true);
+                        await photo.LoadMetadataAsync(useCache: true, token: token);
                         if (token.IsCancellationRequested) return;
 
                         if (photo.Metadata.Width > maxDimension || photo.Metadata.Height > maxDimension)
@@ -263,7 +263,7 @@ public partial class PhotoManager
                     // a slideshow's forward look-ahead bypasses the caps (those images will
                     // be shown full-res momentarily anyway); metadata is still needed below
                     // for an accurate memory estimate
-                    await photo.LoadMetadataAsync(useCache: true);
+                    await photo.LoadMetadataAsync(useCache: true, token: token);
                     if (token.IsCancellationRequested) return;
                 }
 

--- a/source/ImageGlass.Lib/Common/Photoing/Manager/PhotoManager_ListMethods.cs
+++ b/source/ImageGlass.Lib/Common/Photoing/Manager/PhotoManager_ListMethods.cs
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ImageGlass.Common.ServiceProviders.FileSearchService;
 
 namespace ImageGlass.Common.Photoing;
 
@@ -42,6 +43,23 @@ public partial class PhotoManager
     {
         var newItems = filePaths.Select(path => new Photo(path)).ToList();
 
+        AddPhotos(newItems, index);
+    }
+
+
+    /// <summary>
+    /// Adds file-search entries using their captured filesystem metadata.
+    /// </summary>
+    public void Add(IEnumerable<FileSearchEntry> entries, int index = -1)
+    {
+        var newItems = entries.Select(entry => new Photo(entry)).ToList();
+
+        AddPhotos(newItems, index);
+    }
+
+
+    private void AddPhotos(List<Photo> newItems, int index)
+    {
         lock (_lock)
         {
             var addedIndex = index;

--- a/source/ImageGlass.Lib/Common/Photoing/Photos/Photo.cs
+++ b/source/ImageGlass.Lib/Common/Photoing/Photos/Photo.cs
@@ -22,6 +22,7 @@ using Avalonia.Threading;
 using ImageGlass.Common.Extensions;
 using ImageGlass.Common.Loggers;
 using ImageGlass.Common.ServiceProviders;
+using ImageGlass.Common.ServiceProviders.FileSearchService;
 using ImageGlass.Common.Types;
 using ImageMagick;
 using SkiaSharp;
@@ -50,6 +51,7 @@ public partial class Photo : PhDisposable
     // track pending tasks
     private ConcurrentDictionary<Guid, bool> _taskRefs = new();
     private CancellationTokenSource? _cancelThumbnailLoading;
+    private double _galleryThumbnailRequestSize;
 
     /// <summary>
     /// Prevents duplicate concurrent loads of the same photo's thumbnail.
@@ -280,6 +282,14 @@ public partial class Photo : PhDisposable
         ReadOptions = options ?? new();
     }
 
+    /// <summary>
+    /// Initializes a photo with filesystem data captured by folder enumeration.
+    /// </summary>
+    public Photo(FileSearchEntry entry, PhotoReadOptions? options = null)
+    {
+        Metadata = new PhotoMetadata(entry);
+        ReadOptions = options ?? new();
+    }
 
     /// <summary>
     /// Initializes a new single-frame photo using a bitmap source for rendering.
@@ -628,7 +638,7 @@ public partial class Photo : PhDisposable
             if (token.IsCancellationRequested) return;
 
             // load metadata
-            await LoadMetadataAsync(useCache);
+            await LoadMetadataAsync(useCache, token: token);
             PhotoTrace.Mark("metadata:loaded", FilePath, DescribeMetadata(Metadata));
 
             if (!skipLoadingEvent)
@@ -712,9 +722,10 @@ public partial class Photo : PhDisposable
     /// Loads <c><see cref="Metadata"/></c> for the photo.
     /// Returns the cached metadata if it's not null and up-to-date.
     /// </summary>
-    public async Task LoadMetadataAsync(bool useCache, PhotoReadOptions? newOptions = null)
+    public async Task LoadMetadataAsync(bool useCache, PhotoReadOptions? newOptions = null, CancellationToken token = default)
     {
-        var meta = await Task.Run(() => LoadMetadataAsync__(useCache, newOptions)).ConfigureAwait(false);
+        var task = Task.Run(() => LoadMetadataAsync__(useCache, newOptions));
+        var meta = await task.WaitAsync(token).ConfigureAwait(false);
 
         if (meta is not null)
         {
@@ -974,70 +985,79 @@ public partial class Photo : PhDisposable
     /// Uses a semaphore to ensure only one load per photo at a time,
     /// and caches the result on <see cref="GalleryThumbnail"/>.
     /// </summary>
-    public async Task LoadThumbnailAsync(double thumbSize, bool useCache)
+    public async Task LoadThumbnailAsync(double thumbSize, bool useCache, CancellationToken cancellationToken = default)
     {
         // 1. fast path: use cached thumbnail
-        if (useCache && GalleryThumbnail is not null) return;
+        if (useCache && GalleryThumbnail is not null && _galleryThumbnailRequestSize == thumbSize) return;
         if (IsDisposed || string.IsNullOrEmpty(FilePath)) return;
 
         // 2. acquire global throttle to avoid saturating the thread pool
         //    (prevents blocking the main image loading when many thumbnails load at once)
-        await _thumbnailThrottleLock.WaitAsync().ConfigureAwait(false);
+        await _thumbnailThrottleLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
-            await _thumbnailLock.WaitAsync().ConfigureAwait(false);
+            await _thumbnailLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
             {
                 // 3. double-check after acquiring the lock
-                if (useCache && GalleryThumbnail is not null) return;
+                if (useCache && GalleryThumbnail is not null && _galleryThumbnailRequestSize == thumbSize) return;
                 if (IsDisposed) return;
 
                 // reset cancellation for this load
                 _cancelThumbnailLoading?.Dispose();
-                _cancelThumbnailLoading = new CancellationTokenSource();
+                _cancelThumbnailLoading = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var token = _cancelThumbnailLoading.Token;
 
 
-                // 4. load metadata if needed
-                await LoadMetadataAsync(true).ConfigureAwait(false);
-                if (token.IsCancellationRequested) return;
+                // 4. try caches without reading the source file
+                using var diskThumb = useCache
+                    ? await ThumbnailDiskCache.TryGetAsync(
+                        FilePath, (int)thumbSize, Metadata.FileLastWriteTimeUtc, token)
+                        .ConfigureAwait(false)
+                    : null;
+                using var platformThumb = useCache && diskThumb.IsDisposed()
+                    ? await Core.PreviewProvider.TryGetCachedThumbnailAsync(
+                        FilePath, (int)thumbSize, token).ConfigureAwait(false)
+                    : null;
+                var cachedThumb = platformThumb ?? diskThumb;
 
-
-                // 4b. try disk cache
-                var diskThumb = await ThumbnailDiskCache.TryGetAsync(FilePath, (int)thumbSize, token)
-                    .ConfigureAwait(false);
-                if (token.IsCancellationRequested) return;
-
-                // drop entries written by an older, undersized source so they get regenerated
-                var isDiskThumbUsable = PhotoPreviewProvider.IsPreviewLargeEnough(diskThumb, Metadata, thumbSize);
-                if (diskThumb is not null && !isDiskThumbUsable)
+                if (!cachedThumb.IsDisposed())
                 {
-                    diskThumb.Dispose();
-                    diskThumb = null;
-                }
-
-                if (diskThumb is not null)
-                {
-                    PhotoTrace.Mark("thumb:disk-hit", null, $"{FilePath} @ {(int)thumbSize}px");
                     var avBitmapCached = await Task.Run(
-                        () => SkiaCodec.ToWritableBitmap(diskThumb), token)
+                        () => SkiaCodec.ToWritableBitmap(cachedThumb), token)
                         .ConfigureAwait(false);
-                    diskThumb.Dispose();
 
-                    if (token.IsCancellationRequested)
+                    if (avBitmapCached is null) return;
+                    if (!await ShowGalleryThumbnailAsync(avBitmapCached, token)) return;
+
+                    // The requested size includes a supersampling margin.
+                    // If the cached image is smaller than the displayed size,
+                    // show it now but keep looking for a sharper replacement.
+                    var cachedThumbMayBeTooSmall = thumbSize > 0
+                        && Math.Max(cachedThumb.Width, cachedThumb.Height)
+                            < thumbSize * PhotoPreviewProvider.MIN_PREVIEW_SIZE_RATIO;
+                    if (!cachedThumbMayBeTooSmall)
                     {
-                        avBitmapCached?.Dispose();
+                        _galleryThumbnailRequestSize = thumbSize;
                         return;
                     }
+                }
 
-                    GalleryThumbnail = avBitmapCached;
+                // 5. load metadata if needed
+                await LoadMetadataAsync(true, token: token).ConfigureAwait(false);
+                if (token.IsCancellationRequested) return;
+
+                // a small source cannot produce a larger thumbnail.
+                if (PhotoPreviewProvider.IsPreviewLargeEnough(cachedThumb, Metadata, thumbSize))
+                {
+                    _galleryThumbnailRequestSize = thumbSize;
                     return;
                 }
 
 
-                // 5. get thumbnail from platform provider
+                // 6. get thumbnail from platform provider
                 PhotoTrace.Mark("thumb:provider", null, $"{FilePath} @ {(int)thumbSize}px");
                 var swThumb = PhotoTrace.Enabled ? Stopwatch.StartNew() : null;
                 using var skThumb = await Task.Run(
@@ -1052,23 +1072,18 @@ public partial class Photo : PhDisposable
                 }
 
 
-                // 6. convert SKImage to Avalonia Bitmap
+                // 7. convert SKImage to Avalonia Bitmap
                 var avBitmap = await Task.Run(
                     () => SkiaCodec.ToWritableBitmap(skThumb), token)
                     .ConfigureAwait(false);
 
-                if (token.IsCancellationRequested)
-                {
-                    avBitmap?.Dispose();
-                    return;
-                }
+                // 8. update the gallery thumbnail (triggers UI binding update)
+                if (avBitmap is null) return;
+                if (!await ShowGalleryThumbnailAsync(avBitmap, token)) return;
+                _galleryThumbnailRequestSize = thumbSize;
 
 
-                // 7. update the gallery thumbnail (triggers UI binding update)
-                GalleryThumbnail = avBitmap;
-
-
-                // 8. write to disk cache last, so encoding never delays the thumbnail appearing.
+                // 9. write to disk cache last, so encoding never delays the thumbnail appearing.
                 // Awaited (not fire-and-forget) to keep skThumb alive until the encode is done.
                 await ThumbnailDiskCache.PutAsync(FilePath, (int)thumbSize, skThumb, token)
                     .ConfigureAwait(false);
@@ -1105,13 +1120,44 @@ public partial class Photo : PhDisposable
             _cancelThumbnailLoading?.Dispose();
             _cancelThumbnailLoading = null;
 
-            // the setter frees the outgoing bitmap once the binding has let go of it
-            GalleryThumbnail = null;
+            await ClearGalleryThumbnailAsync();
         }
         finally
         {
             _thumbnailLock.Release();
         }
+    }
+
+
+    private async Task<bool> ShowGalleryThumbnailAsync(Bitmap thumbnail, CancellationToken token)
+    {
+        if (token.IsCancellationRequested || IsDisposed)
+        {
+            thumbnail.Dispose();
+            return false;
+        }
+
+        return await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            if (token.IsCancellationRequested || IsDisposed)
+            {
+                thumbnail.Dispose();
+                return false;
+            }
+
+            GalleryThumbnail = thumbnail;
+            return true;
+        });
+    }
+
+
+    private async Task ClearGalleryThumbnailAsync()
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            GalleryThumbnail = null;
+            _galleryThumbnailRequestSize = 0;
+        });
     }
 
 

--- a/source/ImageGlass.Lib/Common/Photoing/Photos/PhotoMetadata.cs
+++ b/source/ImageGlass.Lib/Common/Photoing/Photos/PhotoMetadata.cs
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 using ImageGlass.Common.Types;
+using ImageGlass.Common.ServiceProviders.FileSearchService;
 using ImageMagick;
 using SkiaSharp;
 using System;
@@ -34,17 +35,18 @@ public partial class PhotoMetadata : PhDisposable
     #region Public Properties
 
     #region File metadata
+    private string _filePath = string.Empty;
     public string FilePath
     {
-        get; set
+        get => _filePath;
+        set
         {
-            if (field == value) return;
-            var oldValue = field;
-            field = value;
+            if (_filePath == value) return;
+            _filePath = value;
 
             SetFilePath__(value);
         }
-    } = string.Empty;
+    }
 
     public string FileName { get; private set; } = string.Empty;
     /// <summary>
@@ -198,6 +200,20 @@ public partial class PhotoMetadata : PhDisposable
     }
 
 
+    public PhotoMetadata(FileSearchEntry entry)
+    {
+        // assigned directly to skip SetFilePath__, which re-stats the file from disk
+        _filePath = entry.FilePath;
+
+        FileName = Path.GetFileName(entry.FilePath);
+        FileExtension = Path.GetExtension(entry.FilePath).ToLowerInvariant();
+        FolderPath = Path.GetDirectoryName(entry.FilePath) ?? string.Empty;
+        FolderName = Path.GetFileName(FolderPath);
+        FileSizeInBytes = entry.FileSizeInBytes;
+        FileCreationTimeUtc = entry.FileCreationTimeUtc;
+        FileLastWriteTimeUtc = entry.FileLastWriteTimeUtc;
+        FileLastAccessTimeUtc = entry.FileLastAccessTimeUtc;
+    }
 
     #region Methods
 

--- a/source/ImageGlass.Lib/Common/Photoing/ThumbnailDiskCache.cs
+++ b/source/ImageGlass.Lib/Common/Photoing/ThumbnailDiskCache.cs
@@ -51,14 +51,14 @@ internal static class ThumbnailDiskCache
     /// <summary>
     /// Tries to load a cached thumbnail from disk.
     /// </summary>
-    public static async Task<SKImage?> TryGetAsync(string filePath, int thumbSize, CancellationToken token = default)
+    public static async Task<SKImage?> TryGetAsync(string filePath, int thumbSize, DateTime sourceLastWriteTimeUtc, CancellationToken token = default)
     {
         if (Core.Config.GalleryCacheSizeInMb == 0)
         {
             ScheduleCleanupOnce();
             return null;
         }
-        if (string.IsNullOrEmpty(filePath)) return null;
+        if (string.IsNullOrEmpty(filePath) || sourceLastWriteTimeUtc == default) return null;
 
         var cachePath = GetCacheFilePath(filePath, thumbSize);
 
@@ -70,8 +70,7 @@ internal static class ThumbnailDiskCache
 
                 // validate: cache must be newer than source file
                 var cacheTime = File.GetLastWriteTimeUtc(cachePath);
-                var sourceTime = File.GetLastWriteTimeUtc(filePath);
-                if (cacheTime < sourceTime) return null;
+                if (cacheTime < sourceLastWriteTimeUtc) return null;
 
                 // decode: force immediate rasterization so the image
                 // does not depend on the file-mapped data after this block

--- a/source/ImageGlass.Lib/Common/ServiceProviders/FileSearchService/FileSearchEntry.cs
+++ b/source/ImageGlass.Lib/Common/ServiceProviders/FileSearchService/FileSearchEntry.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ImageGlass - A Fast, Seamless Photo Viewer
 Copyright (C) 2010 - 2026 DUONG DIEU PHAP
 Project homepage: https://imageglass.org
@@ -17,19 +17,36 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 using System;
-using System.Collections.Generic;
+using System.IO;
 
 namespace ImageGlass.Common.ServiceProviders.FileSearchService;
 
 
 /// <summary>
-/// Event arguments for the <see cref="FileSearchProvider.FileSearching"/> event.
+/// Immutable filesystem information captured while enumerating a folder.
 /// </summary>
-public class FileSearchingEventArgs(IReadOnlyList<FileSearchEntry> entries) : EventArgs
+public sealed record FileSearchEntry(
+    string FilePath,
+    long FileSizeInBytes,
+    DateTime FileCreationTimeUtc,
+    DateTime FileLastWriteTimeUtc,
+    DateTime FileLastAccessTimeUtc,
+    FileAttributes Attributes)
 {
     /// <summary>
-    /// Gets the filesystem entries captured during enumeration.
+    /// Creates an entry from an already-enumerated <see cref="FileInfo"/>.
     /// </summary>
-    public IReadOnlyList<FileSearchEntry> Results { get; } = entries;
+    public static FileSearchEntry FromFileInfo(FileInfo file) => new(
+        file.FullName,
+        file.Length,
+        file.CreationTimeUtc,
+        file.LastWriteTimeUtc,
+        file.LastAccessTimeUtc,
+        file.Attributes);
 
+
+    /// <summary>
+    /// Creates an entry for a standalone path.
+    /// </summary>
+    public static FileSearchEntry FromPath(string filePath) => FromFileInfo(new FileInfo(filePath));
 }

--- a/source/ImageGlass.Lib/Common/ServiceProviders/FileSearchService/FileSearchProvider.cs
+++ b/source/ImageGlass.Lib/Common/ServiceProviders/FileSearchService/FileSearchProvider.cs
@@ -35,7 +35,6 @@ namespace ImageGlass.Common.ServiceProviders.FileSearchService;
 public partial class FileSearchProvider() : PhDisposable, IFileSearchProvider
 {
     protected CancellationTokenSource? _cancelSearching;
-    protected Action<FileSearchingEventArgs>? _progressFn;
 
 
     // Public Properties
@@ -45,12 +44,6 @@ public partial class FileSearchProvider() : PhDisposable, IFileSearchProvider
     /// <inheritdoc/>
     /// </summary>
     public FileSearchOptions Options { get; protected set; } = new();
-
-
-    /// <summary>
-    /// Gets a value indicating whether the search operation has completed.
-    /// </summary>
-    public bool IsSearchEnded { get; protected set; } = false;
 
 
     #endregion // Public Properties
@@ -64,12 +57,11 @@ public partial class FileSearchProvider() : PhDisposable, IFileSearchProvider
     /// </summary>
     public async virtual Task SearchAsync(IEnumerable<string> dirs, FileSearchOptions options, Action<FileSearchingEventArgs>? progressFn = null)
     {
-        _progressFn = progressFn;
         Options = options;
 
         // cancel ongoing search
         CancelSearching();
-        IsSearchEnded = false;
+        var token = _cancelSearching.Token;
 
         // snapshot the collection to avoid modification during enumeration
         var dirList = dirs.ToList();
@@ -81,14 +73,12 @@ public partial class FileSearchProvider() : PhDisposable, IFileSearchProvider
             {
                 foreach (var dirPath in dirList)
                 {
-                    if (_cancelSearching.Token.IsCancellationRequested) break;
-                    FindFiles(dirPath, _cancelSearching.Token);
+                    if (token.IsCancellationRequested) break;
+                    FindFiles(dirPath, options, progressFn, token);
                 }
-            }, _cancelSearching.Token);
+            }, token);
         }
         catch { }
-
-        IsSearchEnded = true;
     }
 
 
@@ -117,7 +107,6 @@ public partial class FileSearchProvider() : PhDisposable, IFileSearchProvider
     {
         base.OnDisposing();
 
-        _progressFn = null;
         CancelSearching();
     }
 
@@ -125,14 +114,14 @@ public partial class FileSearchProvider() : PhDisposable, IFileSearchProvider
     /// <summary>
     /// Filters a collection of strings and returns the filtered results.
     /// </summary>
-    protected virtual IEnumerable<string> OnFiltering(IEnumerable<string> fileList,
+    protected virtual IEnumerable<FileSearchEntry> OnFiltering(IEnumerable<FileSearchEntry> fileList,
         FileSearchOptions options)
     {
         if (options.AllowedExtensions is null) return fileList;
 
-        return fileList.Where(path =>
+        return fileList.Where(entry =>
         {
-            var ext = Path.GetExtension(path).ToLowerInvariant();
+            var ext = Path.GetExtension(entry.FilePath).ToLowerInvariant();
 
             return options.AllowedExtensions.Contains(ext);
         });
@@ -142,45 +131,106 @@ public partial class FileSearchProvider() : PhDisposable, IFileSearchProvider
     /// <summary>
     /// Sorts a collection of image file paths based on provided criteria.
     /// </summary>
-    protected virtual IOrderedEnumerable<string> OnSorting(IEnumerable<string> fileList,
+    protected virtual IOrderedEnumerable<FileSearchEntry> OnSorting(IEnumerable<FileSearchEntry> fileList,
         FileSearchOptions options)
     {
-        return SortFiles(fileList, options);
+        return SortEntries(fileList, options);
     }
 
 
     /// <summary>
     /// Finds files in the given directory, emits <see cref="FileSearching"/> event.
     /// </summary>
-    protected void FindFiles(string dirPath, CancellationToken token)
+    protected void FindFiles(string dirPath, FileSearchOptions options,
+        Action<FileSearchingEventArgs>? progressFn, CancellationToken token)
     {
         // cancel if requested
         if (token.IsCancellationRequested) return;
 
         // search files; hidden/system sub-folders are pruned from the recursion too
-        var filePaths = Directory.EnumerateFiles(dirPath, "*",
-            BHelper.GetEnumerationOptions(Options.IncludeHidden, Options.SearchSubDirectories));
+        var entries = EnumerateFileEntries(dirPath, options, options.SearchSubDirectories, token);
 
 
         // cancel if requested
         if (token.IsCancellationRequested) return;
 
         // filter list
-        filePaths = OnFiltering(filePaths, Options);
+        var filePaths = OnFiltering(entries, options);
 
 
         // cancel if requested
         if (token.IsCancellationRequested) return;
 
         // sort list
-        filePaths = OnSorting(filePaths, Options);
+        filePaths = OnSorting(filePaths, options);
 
 
         // cancel if requested
         if (token.IsCancellationRequested) return;
 
         // emits results
-        _progressFn?.Invoke(new FileSearchingEventArgs(filePaths, IsSearchEnded));
+        progressFn?.Invoke(new FileSearchingEventArgs(filePaths.ToList()));
+    }
+
+
+    /// <summary>
+    /// Enumerates files and captures their filesystem metadata.
+    /// </summary>
+    protected static List<FileSearchEntry> EnumerateFileEntries(string dirPath,
+        FileSearchOptions options, bool searchSubDirectories, CancellationToken token)
+    {
+        var entries = new List<FileSearchEntry>();
+        try
+        {
+            foreach (var file in new DirectoryInfo(dirPath).EnumerateFiles("*",
+                BHelper.GetEnumerationOptions(options.IncludeHidden, searchSubDirectories)))
+            {
+                if (token.IsCancellationRequested) break;
+
+                var ext = file.Extension.ToLowerInvariant();
+                if (options.AllowedExtensions is not null
+                    && !options.AllowedExtensions.Contains(ext)) continue;
+
+                entries.Add(FileSearchEntry.FromFileInfo(file));
+            }
+        }
+        catch { }
+
+        return entries;
+    }
+
+
+    /// <summary>
+    /// Sorts a collection of filesystem entries based on provided criteria.
+    /// </summary>
+    private static IOrderedEnumerable<FileSearchEntry> SortEntries(IEnumerable<FileSearchEntry> fileList, FileSearchOptions options)
+    {
+        var filePathComparer = new StringNaturalComparer(options.OrderType == ImageOrderType.Asc, StringComparison.OrdinalIgnoreCase);
+        var dirPathComparer = options.GroupByDir
+            ? new StringNaturalComparer(options.OrderType == ImageOrderType.Asc, StringComparison.OrdinalIgnoreCase)
+            : (IComparer<string?>)Comparer<string>.Create((a, b) => 0);
+        var query = fileList.OrderBy(f => Path.GetDirectoryName(f.FilePath), dirPathComparer);
+
+        if (options.OrderBy == ImageOrderBy.Random)
+        {
+            return query.ThenBy(_ => Guid.NewGuid());
+        }
+
+        var sorted = (options.OrderBy, options.OrderType) switch
+        {
+            (ImageOrderBy.FileSize, ImageOrderType.Desc) => query.ThenByDescending(f => f.FileSizeInBytes),
+            (ImageOrderBy.FileSize, _) => query.ThenBy(f => f.FileSizeInBytes),
+            (ImageOrderBy.DateCreated, ImageOrderType.Desc) => query.ThenByDescending(f => f.FileCreationTimeUtc),
+            (ImageOrderBy.DateCreated, _) => query.ThenBy(f => f.FileCreationTimeUtc),
+            (ImageOrderBy.Extension, _) => query.ThenBy(f => Path.GetExtension(f.FilePath), StringComparer.OrdinalIgnoreCase),
+            (ImageOrderBy.DateAccessed, ImageOrderType.Desc) => query.ThenByDescending(f => f.FileLastAccessTimeUtc),
+            (ImageOrderBy.DateAccessed, _) => query.ThenBy(f => f.FileLastAccessTimeUtc),
+            (ImageOrderBy.DateModified, ImageOrderType.Desc) => query.ThenByDescending(f => f.FileLastWriteTimeUtc),
+            (ImageOrderBy.DateModified, _) => query.ThenBy(f => f.FileLastWriteTimeUtc),
+            _ => query,
+        };
+
+        return sorted.ThenBy(f => Path.GetFileName(f.FilePath), filePathComparer);
     }
 
 

--- a/source/ImageGlass.Lib/Common/ServiceProviders/IPhotoPreviewProvider.cs
+++ b/source/ImageGlass.Lib/Common/ServiceProviders/IPhotoPreviewProvider.cs
@@ -26,6 +26,14 @@ namespace ImageGlass.Common.ServiceProviders;
 public interface IPhotoPreviewProvider
 {
     /// <summary>
+    /// Tries to retrieve a thumbnail that is already present in the platform cache.
+    /// This operation must not decode the source image.
+    /// </summary>
+    Task<SKImage?> TryGetCachedThumbnailAsync(string filePath, int size,
+        CancellationToken token = default);
+
+
+    /// <summary>
     /// Retrieves an embedded thumbnail from either a RAW format or an EXIF profile if exists.
     /// </summary>
     Task<SKImage?> GetPreviewAsync(PhotoMetadata meta, double? minHeight, CancellationToken token = default);

--- a/source/ImageGlass.Lib/Common/ServiceProviders/PhotoPreviewProvider.cs
+++ b/source/ImageGlass.Lib/Common/ServiceProviders/PhotoPreviewProvider.cs
@@ -33,7 +33,14 @@ public class PhotoPreviewProvider : IPhotoPreviewProvider
     /// Callers request 2x the size they display (supersampling margin), so half of it is still
     /// drawn without any upscaling; below that the preview visibly blurs.
     /// </summary>
-    private const double MIN_PREVIEW_SIZE_RATIO = 0.5;
+    internal const double MIN_PREVIEW_SIZE_RATIO = 0.5;
+
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public virtual Task<SKImage?> TryGetCachedThumbnailAsync(string filePath, int size,
+        CancellationToken token = default) => Task.FromResult<SKImage?>(null);
 
 
     /// <summary>

--- a/source/ImageGlass.Lib/UI/BaseControls/PhVirtualizingUniformPanel.cs
+++ b/source/ImageGlass.Lib/UI/BaseControls/PhVirtualizingUniformPanel.cs
@@ -382,10 +382,12 @@ public class PhVirtualizingUniformPanel : VirtualizingPanel, IScrollSnapPointsIn
         var extStart = Math.Max(0, viewportStart - bufferSize);
         var extEnd = viewportEnd + bufferSize;
 
-        var firstVisible = Math.Max(0, (int)(extStart / _itemWidth));
-        var lastVisible = Math.Min(itemCount - 1, (int)(extEnd / _itemWidth));
+        var firstVisible = Math.Max(0, (int)(viewportStart / _itemWidth));
+        var lastVisible = Math.Min(itemCount - 1, (int)(viewportEnd / _itemWidth));
+        var firstRealized = Math.Max(0, (int)(extStart / _itemWidth));
+        var lastRealized = Math.Min(itemCount - 1, (int)(extEnd / _itemWidth));
 
-        RealizeRange(items, firstVisible, lastVisible);
+        RealizeRange(items, firstRealized, lastRealized, firstVisible, lastVisible);
 
         // Measure realized elements
         var constraint = new Size(_itemWidth, _itemHeight);
@@ -445,13 +447,17 @@ public class PhVirtualizingUniformPanel : VirtualizingPanel, IScrollSnapPointsIn
         var extStart = Math.Max(0, viewportStart - bufferSize);
         var extEnd = viewportEnd + bufferSize;
 
-        var firstRow = Math.Max(0, (int)(extStart / _itemHeight));
-        var lastRow = Math.Min(_totalRows - 1, (int)(extEnd / _itemHeight));
+        var firstVisibleRow = Math.Max(0, (int)(viewportStart / _itemHeight));
+        var lastVisibleRow = Math.Min(_totalRows - 1, (int)(viewportEnd / _itemHeight));
+        var firstRealizedRow = Math.Max(0, (int)(extStart / _itemHeight));
+        var lastRealizedRow = Math.Min(_totalRows - 1, (int)(extEnd / _itemHeight));
 
-        var firstVisible = firstRow * _columnsPerRow;
-        var lastVisible = Math.Min(itemCount - 1, (lastRow + 1) * _columnsPerRow - 1);
+        var firstVisible = firstVisibleRow * _columnsPerRow;
+        var lastVisible = Math.Min(itemCount - 1, (lastVisibleRow + 1) * _columnsPerRow - 1);
+        var firstRealized = firstRealizedRow * _columnsPerRow;
+        var lastRealized = Math.Min(itemCount - 1, (lastRealizedRow + 1) * _columnsPerRow - 1);
 
-        RealizeRange(items, firstVisible, lastVisible);
+        RealizeRange(items, firstRealized, lastRealized, firstVisible, lastVisible);
 
         // Measure realized elements
         var constraint = new Size(_itemWidth, _itemHeight);
@@ -492,7 +498,8 @@ public class PhVirtualizingUniformPanel : VirtualizingPanel, IScrollSnapPointsIn
     /// <summary>
     /// Realizes elements in [firstIndex, lastIndex] range and recycles out-of-range ones.
     /// </summary>
-    private void RealizeRange(IReadOnlyList<object?> items, int firstIndex, int lastIndex)
+    private void RealizeRange(IReadOnlyList<object?> items, int firstIndex, int lastIndex,
+        int visibleFirstIndex, int visibleLastIndex)
     {
         // 1) Recycle elements outside the new range
         for (var i = _realizedElements.Count - 1; i >= 0; i--)
@@ -512,15 +519,21 @@ public class PhVirtualizingUniformPanel : VirtualizingPanel, IScrollSnapPointsIn
             realizedIndices.Add(_realizedElements[i].Index);
         }
 
-        // 3) Realize missing elements in range
-        for (var idx = firstIndex; idx <= lastIndex; idx++)
+        // 3) Realize visible elements before the buffered range so their thumbnails start first.
+        void RealizeMissingRange(int start, int end)
         {
-            if (idx < 0 || idx >= items.Count) continue;
-            if (realizedIndices.Contains(idx)) continue;
+            for (var idx = start; idx <= end; idx++)
+            {
+                if (idx < 0 || idx >= items.Count || realizedIndices.Contains(idx)) continue;
 
-            var element = GetOrCreateElement(items, idx);
-            _realizedElements.Add(new RealizedElement(idx, element));
+                var element = GetOrCreateElement(items, idx);
+                _realizedElements.Add(new RealizedElement(idx, element));
+            }
         }
+
+        RealizeMissingRange(visibleFirstIndex, visibleLastIndex);
+        RealizeMissingRange(firstIndex, visibleFirstIndex - 1);
+        RealizeMissingRange(visibleLastIndex + 1, lastIndex);
     }
 
 

--- a/source/ImageGlass.Lib/UI/Gallery/GalleryControl.axaml.cs
+++ b/source/ImageGlass.Lib/UI/Gallery/GalleryControl.axaml.cs
@@ -148,6 +148,13 @@ public partial class GalleryControl : PhControl
     }
 
 
+    protected override void OnIgDpiChanged()
+    {
+        base.OnIgDpiChanged();
+        RefreshRealizedThumbnails();
+    }
+
+
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
     {
         base.OnPropertyChanged(e);
@@ -156,6 +163,10 @@ public partial class GalleryControl : PhControl
         {
             RaisePropertyChanged(MinContentSizeProperty, default, MinContentSize);
             UpdateReservedSize();
+        }
+        else if (e.Property == IsContentVisibleProperty)
+        {
+            RefreshRealizedThumbnails();
         }
     }
 
@@ -166,6 +177,7 @@ public partial class GalleryControl : PhControl
         {
             RaisePropertyChanged(MinContentSizeProperty, default, MinContentSize);
             UpdateReservedSize();
+            RefreshRealizedThumbnails();
         }
     }
 
@@ -228,6 +240,16 @@ public partial class GalleryControl : PhControl
 
         var thumbSize = Core.Config.ThumbnailSize * Dpi * 2;
         _ = photo.LoadThumbnailAsync(thumbSize, useCache);
+    }
+
+
+    private void RefreshRealizedThumbnails()
+    {
+        foreach (var item in PART_ItemsControl.GetVisualDescendants().OfType<GalleryItem>())
+        {
+            if (IsContentVisible) item.LoadThumbnail();
+            else item.CancelThumbnailLoading();
+        }
     }
 
 

--- a/source/ImageGlass.Lib/UI/Gallery/GalleryItem.axaml.cs
+++ b/source/ImageGlass.Lib/UI/Gallery/GalleryItem.axaml.cs
@@ -16,13 +16,20 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Interactivity;
+using ImageGlass.Common;
 using ImageGlass.Common.Photoing;
+using System;
+using System.Threading;
 
 namespace ImageGlass.UI;
 
 public partial class GalleryItem : PhToolButton
 {
+    private CancellationTokenSource? _thumbnailCts;
+    private Photo? _tooltipReadyPhoto;
     public Photo VM => (Photo)DataContext!;
 
 
@@ -30,17 +37,72 @@ public partial class GalleryItem : PhToolButton
     public GalleryItem()
     {
         InitializeComponent();
+        ToolTip.AddToolTipOpeningHandler(this, ToolTip_Opening);
     }
 
 
     protected override void OnLoaded(RoutedEventArgs e)
     {
         base.OnLoaded(e);
+        LoadThumbnail();
+    }
 
-        if (DataContext is Photo photo)
+
+    protected override void OnUnloaded(RoutedEventArgs e)
+    {
+        CancelThumbnailLoading();
+        base.OnUnloaded(e);
+    }
+
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+
+        if (e.Property == DataContextProperty)
         {
-            _ = photo.LoadThumbnailAsync(Dpi);
+            _tooltipReadyPhoto = null;
+            if (DataContext is Photo) LoadThumbnail();
+            else CancelThumbnailLoading();
         }
+    }
+
+
+    internal async void LoadThumbnail(bool useCache = true)
+    {
+        CancelThumbnailLoading();
+        if (DataContext is not Photo photo) return;
+
+        _thumbnailCts = new CancellationTokenSource();
+        try
+        {
+            var thumbSize = Core.Config.ThumbnailSize * Dpi * 2;
+            await photo.LoadThumbnailAsync(thumbSize, useCache, _thumbnailCts.Token);
+        }
+        catch (OperationCanceledException) { }
+    }
+
+
+    internal void CancelThumbnailLoading()
+    {
+        _thumbnailCts?.Cancel();
+        _thumbnailCts?.Dispose();
+        _thumbnailCts = null;
+    }
+
+
+    private async void ToolTip_Opening(object? sender, CancelRoutedEventArgs e)
+    {
+        if (DataContext is not Photo photo) return;
+        if (ReferenceEquals(_tooltipReadyPhoto, photo) || photo.Metadata.FrameCount > 0) return;
+
+        e.Cancel = true;
+        await photo.LoadMetadataAsync(true);
+
+        if (!ReferenceEquals(DataContext, photo) || !IsPointerOver) return;
+
+        _tooltipReadyPhoto = photo;
+        ToolTip.SetIsOpen(this, true);
     }
 
 }

--- a/source/ImageGlass.Win32/Common/ServiceProviders/Win32FileSearchProvider.cs
+++ b/source/ImageGlass.Win32/Common/ServiceProviders/Win32FileSearchProvider.cs
@@ -57,23 +57,32 @@ public partial class Win32FileSearchProvider : FileSearchProvider
     /// </summary>
     public override async Task SearchAsync(IEnumerable<string> dirs, FileSearchOptions options, Action<FileSearchingEventArgs>? progressFn = null)
     {
-        _progressFn = progressFn;
         Options = options;
 
         // cancel ongoing search
         CancelSearching();
-        IsSearchEnded = false;
+        var token = _cancelSearching.Token;
+
+        // Publishing on the UI thread serializes old-search cancellation with list updates.
+        Action<FileSearchingEventArgs>? publish = progressFn is null
+            ? null
+            : e => Dispatcher.UIThread.Post(() =>
+            {
+                if (!token.IsCancellationRequested) progressFn(e);
+            });
 
 
         // 1. get files from the foreground window
-        if (Options.ForegroundShell != null && Options.UseExplorerSortOrder)
+        if (options.ForegroundShell != null && options.UseExplorerSortOrder)
         {
             Dispatcher.UIThread.Post(() =>
             {
+                if (token.IsCancellationRequested) return;
+
                 try
                 {
-                    var folderShell = GetShellFolderView(null, (ExplorerView?)Options.ForegroundShell);
-                    FindFiles_WithShell(folderShell.View, folderShell.DirPath, _cancelSearching.Token);
+                    var folderShell = GetShellFolderView(null, (ExplorerView?)options.ForegroundShell);
+                    FindFiles_WithShell(folderShell.View, folderShell.DirPath, options, publish, token);
                 }
                 catch (COMException) { }
             });
@@ -86,11 +95,13 @@ public partial class Win32FileSearchProvider : FileSearchProvider
         var fvMap = new ConcurrentDictionary<string, ExplorerFolderView?>();
         var dirList = dirs.ToList();
 
-        if (Options.UseExplorerSortOrder)
+        if (options.UseExplorerSortOrder)
         {
             // find and save all shell folder view
             foreach (var dirPath in dirList)
             {
+                if (token.IsCancellationRequested) return;
+
                 var folderShell = await Dispatcher.UIThread.InvokeAsync(() =>
                 {
                     var dirShell = GetShellFolderView(dirPath, null);
@@ -108,6 +119,7 @@ public partial class Win32FileSearchProvider : FileSearchProvider
         {
             foreach (var dirPath in dirList)
             {
+                if (token.IsCancellationRequested) break;
                 var folderShellView = fvMap.GetValueOrDefault(dirPath);
 
                 // with shell
@@ -115,21 +127,21 @@ public partial class Win32FileSearchProvider : FileSearchProvider
                 {
                     Dispatcher.UIThread.Post(() =>
                     {
-                        FindFiles_WithShell(folderShellView, dirPath, _cancelSearching.Token);
+                        if (!token.IsCancellationRequested)
+                        {
+                            FindFiles_WithShell(folderShellView, dirPath, options, publish, token);
+                        }
                     });
                 }
 
                 // without shell
                 else
                 {
-                    FindFiles(dirPath, _cancelSearching.Token);
+                    FindFiles(dirPath, options, publish, token);
                 }
             }
         });
 
-
-        // 4. end searching
-        IsSearchEnded = true;
 
         // dipose shell objects
         fvMap.Clear();
@@ -140,7 +152,9 @@ public partial class Win32FileSearchProvider : FileSearchProvider
     /// Finds files in the given <see cref="ExplorerFolderView"/>.
     /// Use the <see cref="FilesEnumerated"/> event to get results.
     /// </summary>
-    private void FindFiles_WithShell(ExplorerFolderView? fv, string? rootDir, CancellationToken token)
+    private void FindFiles_WithShell(ExplorerFolderView? fv, string? rootDir,
+        FileSearchOptions options, Action<FileSearchingEventArgs>? progressFn,
+        CancellationToken token)
     {
         // if no folder view
         if (fv is null)
@@ -148,77 +162,86 @@ public partial class Win32FileSearchProvider : FileSearchProvider
             // use .NET
             if (!string.IsNullOrWhiteSpace(rootDir))
             {
-                FindFiles(rootDir, token);
+                FindFiles(rootDir, options, progressFn, token);
             }
             return;
         }
 
 
-        // 1. get & filter files from shell folder view
-        var filePaths = fv.GetItems(FolderItemViewOptions.SVGIO_FLAG_VIEWORDER)
-            .Where(path =>
+        // shell determines which items are shown and in what order.
+        var shellPaths = fv.GetItems(FolderItemViewOptions.SVGIO_FLAG_VIEWORDER).ToArray();
+
+        // directory enumeration provides their filesystem metadata.
+        var isFileSystemDirectory = !string.IsNullOrWhiteSpace(rootDir)
+            && Path.IsPathFullyQualified(rootDir)
+            && Directory.Exists(rootDir);
+        var entriesByPath = isFileSystemDirectory
+            ? EnumerateFileEntries(rootDir!, options, false, token).ToDictionary(entry => entry.FilePath, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, FileSearchEntry>(StringComparer.OrdinalIgnoreCase);
+
+        if (token.IsCancellationRequested) return;
+
+        var entries = shellPaths
+            .Select(path =>
             {
                 // ignore special folders
-                if (path.StartsWith(EggShell.SPECIAL_DIR_PREFIX, StringComparison.InvariantCultureIgnoreCase)) return false;
+                if (path.StartsWith(EggShell.SPECIAL_DIR_PREFIX, StringComparison.InvariantCultureIgnoreCase)) return null;
+
+                // filter unsupported Shell items
+                if (options.AllowedExtensions is not null)
+                {
+                    var ext = Path.GetExtension(path).ToLowerInvariant();
+                    if (!options.AllowedExtensions.Contains(ext)) return null;
+                }
 
                 try
                 {
-                    // get path attributes
-                    var attrs = File.GetAttributes(path);
+                    var entry = entriesByPath.GetValueOrDefault(path) ?? FileSearchEntry.FromPath(path);
+                    var attrs = entry.Attributes;
 
                     // path is dir
-                    if (attrs.HasFlag(FileAttributes.Directory)) return false;
+                    if (attrs.HasFlag(FileAttributes.Directory)) return null;
 
                     // path is hidden/system
-                    if ((attrs & BHelper.GetSkippedFileAttributes(Options.IncludeHidden)) != 0) return false;
+                    if ((attrs & BHelper.GetSkippedFileAttributes(options.IncludeHidden)) != 0) return null;
+
+                    return entry;
                 }
                 catch
                 {
-                    return false;
+                    return null;
                 }
+            })
+            .Where(entry => entry is not null)
+            .Cast<FileSearchEntry>()
+            .ToList();
 
-                // filter extensions
-                if (Options.AllowedExtensions is not null)
-                {
-                    var ext = Path.GetExtension(path).ToLowerInvariant();
+        // cancel if requested
+        if (token.IsCancellationRequested) return;
 
-                    return Options.AllowedExtensions.Contains(ext);
-                }
-
-                return true;
-            });
+        // emit results
+        progressFn?.Invoke(new FileSearchingEventArgs(entries));
 
 
         // cancel if requested
         if (token.IsCancellationRequested) return;
 
 
-        // 3. emits results
-        _progressFn?.Invoke(new FileSearchingEventArgs(filePaths, IsSearchEnded));
-
-
-        // cancel if requested
-        if (token.IsCancellationRequested) return;
-
-
-        // 4. search all sub-directories if root dir is a real filesystem directory.
+        // search all sub-directories if root dir is a real filesystem directory.
         // Skip for shell URIs like `search-ms:` or `shell:` which are not valid paths
         // for Directory.EnumerateDirectories and would throw IOException.
         // https://github.com/d2phap/ImageGlass/issues/2189
-        if (Options.SearchSubDirectories
-            && !string.IsNullOrWhiteSpace(rootDir)
-            && Path.IsPathFullyQualified(rootDir)
-            && Directory.Exists(rootDir))
+        if (options.SearchSubDirectories && isFileSystemDirectory)
         {
             // search files for the sub dirs
             // get sub folders
-            var subDirList = Directory.EnumerateDirectories(rootDir, "*",
-                BHelper.GetEnumerationOptions(Options.IncludeHidden));
+            var subDirList = Directory.EnumerateDirectories(rootDir!, "*",
+                BHelper.GetEnumerationOptions(options.IncludeHidden));
 
             // find files in sub-folders
             foreach (var dirPath in subDirList)
             {
-                FindFiles(dirPath, token);
+                FindFiles(dirPath, options, progressFn, token);
             }
         }
     }

--- a/source/ImageGlass.Win32/Common/ServiceProviders/Win32PhotoPreviewProvider.cs
+++ b/source/ImageGlass.Win32/Common/ServiceProviders/Win32PhotoPreviewProvider.cs
@@ -29,6 +29,29 @@ namespace ImageGlass.Win32.Common.ServiceProviders;
 
 public class Win32PhotoPreviewProvider : PhotoPreviewProvider
 {
+    private static readonly SemaphoreSlim _shellCacheLock = new(1, 1);
+
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public override async Task<SKImage?> TryGetCachedThumbnailAsync(string filePath, int size,
+        CancellationToken token = default)
+    {
+        if (!Core.Config.EnableGalleryShellThumbnail) return null;
+
+        await _shellCacheLock.WaitAsync(token).ConfigureAwait(false);
+        try
+        {
+            return await Task.Run(
+                () => Win32ShellThumbnailApi.GetThumbnail(filePath, size, size, true), token)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            _shellCacheLock.Release();
+        }
+    }
 
     /// <summary>
     /// <inheritdoc/>


### PR DESCRIPTION
### 🟢 Summary
Improves gallery performance and responsiveness, especially for larger folders and slower HDDs, and when using Windows shell thumbnails.

There are multiple changes:
- captures filesystem metadata during directory enumeration, avoiding separate metadata queries later
- additional image metadata for tooltips is loaded on demand
- cancels obsolete thumbnail work while scrolling and prioritizes items in and near the current viewport
- makes thumbnail-size changes responsive and reloads thumbnails at the required resolution
- checks ImageGlass and Windows Shell thumbnail caches before loading image metadata or decoding the source
- displays an available lower-res thumbnail while a sharper thumbnail is loading
- fixes gallery tooltips sometimes showing incomplete metadata, such as 0×0 resolution or missing color-space information

I started looking at the gallery because I noticed that the app would take longer to launch when opening an image on my network share in a folder with around 1000 images with the gallery open. Additionally, the thumbnails would be loaded slowly when scrolling.

A video of how it behaves on my network share folder with 644 images (the first half is the current 10.0.3.720-rc-win-x64, the second is with the changes from this PR):

https://github.com/user-attachments/assets/6db4f0dc-89aa-4fb2-ac43-a347fa9147f8

### 🟢 Contributor License Agreement (CLA)
By submitting this pull request, I confirm that:
- [x] I agree to the [**ImageGlass Contributor License Agreement (CLA)**](../CLA.md)
