### PR TITLE
Fix dead Crowdin invite link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Large or architectural changes are best discussed first in an [issue](https://gi
 
 ## Translations
 
-Translations for both ImageGlass 10 and ImageGlass 9 are managed on [Crowdin](https://crowdin.com/project/imageglass/invite). Join the project there, pick your language, and translate in the browser. No build tools needed, and no pull request to open.
+Translations for both ImageGlass 10 and ImageGlass 9 are managed on [Crowdin](https://crowdin.com/project/imageglass). Join the project there, pick your language, and translate in the browser. No build tools needed, and no pull request to open.
 
 ImageGlass 10 uses language packs (`*.iglang.json`), so you can also work on a pack locally and test it before it goes to Crowdin:
 


### PR DESCRIPTION
### 🟢 Summary

Fixes the dead Crowdin invitation link in `CONTRIBUTING.md` (line 82).

The **Translations** section pointed to `https://crowdin.com/project/imageglass/invite`, which returns **HTTP 404** (the invitation link has expired), so contributors following the guide could not reach the translation project. It now links to the Crowdin project page directly: `https://crowdin.com/project/imageglass` (verified, returns HTTP 200).

### 🟢 Contributor License Agreement (CLA)
By submitting this pull request, I confirm that:
- [x] I agree to the [**ImageGlass Contributor License Agreement (CLA)**](../CLA.md)

---
Co-authored-by: FirmamentalSpring <287222957+FirmaSpring@users.noreply.github.com>
